### PR TITLE
Change mechanism for component evaluation, support TLA vars

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -92,6 +92,7 @@ type StdOptions interface {
 	Stdout() io.Writer                                     // output to write to
 	DefaultNamespace(env string) string                    // the default namespace for the supplied environment
 	Confirm(context string) error                          // confirmation function for dangerous operations
+	EvalConcurrency() int                                  // the concurrency using which to evaluate components
 }
 
 // Client encapsulates all remote operations needed for the superset of all commands.

--- a/internal/commands/filter.go
+++ b/internal/commands/filter.go
@@ -65,10 +65,11 @@ func filteredObjects(req StdOptions, env string, fp filterParams) ([]model.K8sLo
 	}
 	jvm := req.VM()
 	output, err := eval.Components(components, eval.Context{
-		App:     req.App().Name(),
-		Env:     env,
-		VM:      jvm,
-		Verbose: req.Verbosity() > 1,
+		App:         req.App().Name(),
+		Env:         env,
+		VM:          jvm,
+		Verbose:     req.Verbosity() > 1,
+		Concurrency: req.EvalConcurrency(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -101,12 +101,13 @@ func (c *client) Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, err
 }
 
 type opts struct {
-	app       *model.App
-	client    *client
-	colorize  bool
-	verbosity int
-	out       io.Writer
-	defaultNs string
+	app         *model.App
+	client      *client
+	colorize    bool
+	verbosity   int
+	out         io.Writer
+	defaultNs   string
+	concurrency int
 }
 
 func (o *opts) App() *model.App {
@@ -142,6 +143,10 @@ func (o *opts) DefaultNamespace(env string) string {
 
 func (o *opts) Client(env string) (Client, error) {
 	return o.client, nil
+}
+
+func (o *opts) EvalConcurrency() int {
+	return o.concurrency
 }
 
 func (o *opts) Stdout() io.Writer {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -63,9 +63,13 @@ func TestEvalComponents(t *testing.T) {
 			Name: "a",
 			File: "testdata/components/a.json",
 		},
+		{
+			Name: "tla",
+			File: "testdata/components/tla.jsonnet",
+		},
 	}, Context{Env: "dev", Verbose: true})
 	require.Nil(t, err)
-	require.Equal(t, 3, len(objs))
+	require.Equal(t, 4, len(objs))
 	a := assert.New(t)
 
 	obj := objs[0]
@@ -86,6 +90,34 @@ func TestEvalComponents(t *testing.T) {
 	a.Equal("c", obj.Component())
 	a.Equal("dev", obj.Environment())
 	a.Equal("jsonnet-config-map", obj.GetName())
+
+	obj = objs[3]
+	a.Equal("tla", obj.Component())
+	a.Equal("dev", obj.Environment())
+	a.Equal("tla-v1", obj.GetName())
+}
+
+func TestEvalTLAVariablePropagation(t *testing.T) {
+	jvm := vm.New(vm.Config{
+		TopLevelVars: map[string]string{
+			"suffix": "foobar",
+		},
+	})
+	objs, err := Components([]model.Component{
+		{
+			Name: "tla",
+			File: "testdata/components/tla.jsonnet",
+		},
+	}, Context{Env: "dev", VM: jvm})
+
+	require.Nil(t, err)
+	require.Equal(t, 1, len(objs))
+	a := assert.New(t)
+
+	obj := objs[0]
+	a.Equal("tla", obj.Component())
+	a.Equal("dev", obj.Environment())
+	a.Equal("tla-foobar", obj.GetName())
 }
 
 func TestEvalComponentsBadJson(t *testing.T) {

--- a/internal/eval/object-extract.go
+++ b/internal/eval/object-extract.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/splunk/qbec/internal/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -102,11 +101,7 @@ func (w *walker) walkObjects(path string, component string, data interface{}) ([
 	return ret, nil
 }
 
-func k8sObjectsFromJSONString(str string, app, env string) ([]model.K8sLocalObject, error) {
-	var data interface{}
-	if err := json.Unmarshal([]byte(str), &data); err != nil {
-		return nil, errors.Wrap(err, "JSON unmarshal")
-	}
+func k8sObjectsFromJSON(data map[string]interface{}, app, env string) ([]model.K8sLocalObject, error) {
 	w := walker{app: app, env: env, data: data}
 	ret, err := w.walk()
 	if err != nil {

--- a/internal/eval/testdata/components/tla.jsonnet
+++ b/internal/eval/testdata/components/tla.jsonnet
@@ -1,0 +1,11 @@
+function (suffix='v1') {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'tla-' + suffix,
+  },
+  data: {
+    foo: 'bar',
+  }
+}
+

--- a/setup.go
+++ b/setup.go
@@ -36,12 +36,13 @@ import (
 )
 
 type gOpts struct {
-	verbose   int            // verbosity level
-	app       *model.App     // app loaded from file
-	config    vm.Config      // jsonnet VM config
-	k8sConfig *remote.Config // remote config for k8s, when needed
-	colors    bool           // colorize output
-	yes       bool           // auto-confirm
+	verbose         int            // verbosity level
+	app             *model.App     // app loaded from file
+	config          vm.Config      // jsonnet VM config
+	k8sConfig       *remote.Config // remote config for k8s, when needed
+	colors          bool           // colorize output
+	yes             bool           // auto-confirm
+	evalConcurrency int            // concurrency of component eval
 }
 
 func (g gOpts) App() *model.App {
@@ -59,6 +60,10 @@ func (g gOpts) Colorize() bool {
 
 func (g gOpts) Verbosity() int {
 	return g.verbose
+}
+
+func (g gOpts) EvalConcurrency() int {
+	return g.evalConcurrency
 }
 
 type client struct {
@@ -250,6 +255,7 @@ func setup(root *cobra.Command) {
 	root.PersistentFlags().IntVarP(&opts.verbose, "verbose", "v", 0, "verbosity level")
 	root.PersistentFlags().BoolVar(&opts.colors, "colors", false, "colorize output (set automatically if not specified)")
 	root.PersistentFlags().BoolVar(&opts.yes, "yes", false, "do not prompt for confirmation")
+	root.PersistentFlags().IntVar(&opts.evalConcurrency, "eval-concurrency", 5, "concurrency with which to evaluate components")
 
 	root.AddCommand(newOptionsCommand(root))
 	root.AddCommand(newVersionCommand())


### PR DESCRIPTION
Previously components were evaluated by creating a megacomponent that imported
JSON, YAML and JSONNET files. In particular, jsonnet files were `imported`
which meant that they had no top-level.

We change this to evaluate every component in its own jsonnet VM such that the
top-level nature of the component jsonnet is maintained allowed for TLA vars to
be passed in.

Processing components like this leads to 30-40% overhead so we need to evaluate
components concurrently. This is done with a default concurrency of 5. The user
can change this number using the persistent `--eval-concurrency` flag.

This change has the following benefits and no downside (as far as I can tell)

* Allow for tla variables to be used in jsonnet components
* Reduce time to evaluate a large set of components
* Produce better ereror messages that have the failed component name when things
  do not load correctly.