### PR TITLE
Change mechanism for component evaluation

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -92,6 +92,7 @@ type StdOptions interface {
 	Stdout() io.Writer                                     // output to write to
 	DefaultNamespace(env string) string                    // the default namespace for the supplied environment
 	Confirm(context string) error                          // confirmation function for dangerous operations
+	EvalConcurrency() int                                  // the concurrency using which to evaluate components
 }
 
 // Client encapsulates all remote operations needed for the superset of all commands.

--- a/internal/commands/filter.go
+++ b/internal/commands/filter.go
@@ -65,10 +65,11 @@ func filteredObjects(req StdOptions, env string, fp filterParams) ([]model.K8sLo
 	}
 	jvm := req.VM()
 	output, err := eval.Components(components, eval.Context{
-		App:     req.App().Name(),
-		Env:     env,
-		VM:      jvm,
-		Verbose: req.Verbosity() > 1,
+		App:         req.App().Name(),
+		Env:         env,
+		VM:          jvm,
+		Verbose:     req.Verbosity() > 1,
+		Concurrency: req.EvalConcurrency(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -101,12 +101,13 @@ func (c *client) Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, err
 }
 
 type opts struct {
-	app       *model.App
-	client    *client
-	colorize  bool
-	verbosity int
-	out       io.Writer
-	defaultNs string
+	app         *model.App
+	client      *client
+	colorize    bool
+	verbosity   int
+	out         io.Writer
+	defaultNs   string
+	concurrency int
 }
 
 func (o *opts) App() *model.App {
@@ -142,6 +143,10 @@ func (o *opts) DefaultNamespace(env string) string {
 
 func (o *opts) Client(env string) (Client, error) {
 	return o.client, nil
+}
+
+func (o *opts) EvalConcurrency() int {
+	return o.concurrency
 }
 
 func (o *opts) Stdout() io.Writer {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -20,7 +20,9 @@ package eval
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/splunk/qbec/internal/model"
@@ -28,12 +30,18 @@ import (
 	"github.com/splunk/qbec/internal/vm"
 )
 
+const (
+	defaultConcurrency = 5
+	maxDisplayErrors   = 3
+)
+
 // Context is the evaluation context
 type Context struct {
-	App     string // the application for which the evaluation is done
-	Env     string // the environment for which the evaluation is done
-	VM      *vm.VM // the base VM to use for eval
-	Verbose bool   // show generated code
+	App         string // the application for which the evaluation is done
+	Env         string // the environment for which the evaluation is done
+	VM          *vm.VM // the base VM to use for eval
+	Verbose     bool   // show generated code
+	Concurrency int    // concurrent components to evaluate, default 5
 }
 
 // Components evaluates the specified components using the specific runtime
@@ -42,11 +50,11 @@ func Components(components []model.Component, ctx Context) ([]model.K8sLocalObje
 	if ctx.VM == nil {
 		ctx.VM = vm.New(vm.Config{})
 	}
-	cCode, err := evalComponents(components, ctx)
+	componentMap, err := evalComponents(components, ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "evaluate components")
+		return nil, err
 	}
-	objs, err := k8sObjectsFromJSONString(cCode, ctx.App, ctx.Env)
+	objs, err := k8sObjectsFromJSON(componentMap, ctx.App, ctx.Env)
 	if err != nil {
 		return nil, errors.Wrap(err, "extract objects")
 	}
@@ -80,34 +88,87 @@ func Params(file string, ctx Context) (map[string]interface{}, error) {
 	return ret, nil
 }
 
-func evalComponents(list []model.Component, ctx Context) (string, error) {
-	cfg := ctx.VM.Config().WithVars(map[string]string{model.QbecNames.EnvVarName: ctx.Env})
-	jvm := vm.New(cfg)
-	var lines []string
-	for _, c := range list {
-		switch {
-		case strings.HasSuffix(c.File, ".yaml"):
-			lines = append(lines, fmt.Sprintf("'%s': parseYaml(importstr '%s')", c.Name, c.File))
-		case strings.HasSuffix(c.File, ".json"):
-			lines = append(lines, fmt.Sprintf("'%s': parseJson(importstr '%s')", c.Name, c.File))
-		default:
-			lines = append(lines, fmt.Sprintf("'%s': import '%s'", c.Name, c.File))
+func evalComponent(jvm *vm.VM, c model.Component) (interface{}, error) {
+	var inputCode string
+	contextFile := c.File
+	switch {
+	case strings.HasSuffix(c.File, ".yaml"):
+		inputCode = fmt.Sprintf("std.native('parseYaml')(importstr '%s')", c.File)
+		contextFile = "yaml-loader.jsonnet"
+	case strings.HasSuffix(c.File, ".json"):
+		inputCode = fmt.Sprintf("std.native('parseJson')(importstr '%s')", c.File)
+		contextFile = "json-loader.jsonnet"
+	default:
+		b, err := ioutil.ReadFile(c.File)
+		if err != nil {
+			return nil, errors.Wrap(err, "read inputCode for "+c.File)
 		}
+		inputCode = string(b)
 	}
-	preamble := []string{
-		"local parseYaml = std.native('parseYaml');",
-		"local parseJson = std.native('parseJson');",
-	}
-	code := strings.Join(preamble, "\n") + "\n{\n  " + strings.Join(lines, ",\n  ") + "\n}"
-	if ctx.Verbose {
-		sio.Debugln("Eval components:\n" + code)
-	}
-	ret, err := jvm.EvaluateSnippet("component-loader.jsonnet", code)
+	evalCode, err := jvm.EvaluateSnippet(contextFile, inputCode)
 	if err != nil {
-		return "", err
+		return nil, errors.Wrap(err, fmt.Sprintf("evaluate '%s'", c.Name))
 	}
-	if ctx.Verbose {
-		sio.Debugln("Eval components output:\n" + prettyJSON(ret))
+	var data interface{}
+	if err := json.Unmarshal([]byte(evalCode), &data); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("unexpected unmarshal '%s'", c.File))
+	}
+	return data, nil
+}
+
+func evalComponents(list []model.Component, ctx Context) (map[string]interface{}, error) {
+	ret := map[string]interface{}{}
+	if len(list) == 0 {
+		return ret, nil
+	}
+
+	ch := make(chan model.Component, len(list))
+	for _, c := range list {
+		ch <- c
+	}
+	close(ch)
+
+	var errs []error
+	var l sync.Mutex
+
+	concurrency := ctx.Concurrency
+	if concurrency <= 0 {
+		concurrency = defaultConcurrency
+	}
+	if concurrency > len(list) {
+		concurrency = len(list)
+	}
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	cfg := ctx.VM.Config().WithVars(map[string]string{model.QbecNames.EnvVarName: ctx.Env})
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			jvm := vm.New(cfg)
+			for c := range ch {
+				obj, err := evalComponent(jvm, c)
+				l.Lock()
+				if err != nil {
+					errs = append(errs, err)
+				} else {
+					ret[c.Name] = obj
+				}
+				l.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if len(errs) > 0 {
+		var msgs []string
+		for i, e := range errs {
+			if i == maxDisplayErrors {
+				msgs = append(msgs, fmt.Sprintf("... and %d more errors", len(errs)-maxDisplayErrors))
+				break
+			}
+			msgs = append(msgs, e.Error())
+		}
+		return nil, errors.New(strings.Join(msgs, "\n"))
 	}
 	return ret, nil
 }

--- a/internal/eval/object-extract.go
+++ b/internal/eval/object-extract.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/splunk/qbec/internal/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -102,11 +101,7 @@ func (w *walker) walkObjects(path string, component string, data interface{}) ([
 	return ret, nil
 }
 
-func k8sObjectsFromJSONString(str string, app, env string) ([]model.K8sLocalObject, error) {
-	var data interface{}
-	if err := json.Unmarshal([]byte(str), &data); err != nil {
-		return nil, errors.Wrap(err, "JSON unmarshal")
-	}
+func k8sObjectsFromJSON(data map[string]interface{}, app, env string) ([]model.K8sLocalObject, error) {
 	w := walker{app: app, env: env, data: data}
 	ret, err := w.walk()
 	if err != nil {

--- a/internal/eval/testdata/bad-components/e1.jsonnet
+++ b/internal/eval/testdata/bad-components/e1.jsonnet
@@ -1,0 +1,5 @@
+{
+  apiVersion: 'v1, //deliberate syntax error
+  kind: 'ConfigMap',
+}
+

--- a/internal/eval/testdata/bad-components/e2.jsonnet
+++ b/internal/eval/testdata/bad-components/e2.jsonnet
@@ -1,0 +1,5 @@
+{
+  apiVersion: 'v1, //deliberate syntax error
+  kind: 'ConfigMap',
+}
+

--- a/internal/eval/testdata/bad-components/e3.jsonnet
+++ b/internal/eval/testdata/bad-components/e3.jsonnet
@@ -1,0 +1,5 @@
+{
+  apiVersion: 'v1, //deliberate syntax error
+  kind: 'ConfigMap',
+}
+

--- a/internal/eval/testdata/bad-components/e4.jsonnet
+++ b/internal/eval/testdata/bad-components/e4.jsonnet
@@ -1,0 +1,5 @@
+{
+  apiVersion: 'v1, //deliberate syntax error
+  kind: 'ConfigMap',
+}
+

--- a/internal/eval/testdata/bad-components/e5.jsonnet
+++ b/internal/eval/testdata/bad-components/e5.jsonnet
@@ -1,0 +1,5 @@
+{
+  apiVersion: 'v1, //deliberate syntax error
+  kind: 'ConfigMap',
+}
+

--- a/internal/eval/testdata/good-components/g1.jsonnet
+++ b/internal/eval/testdata/good-components/g1.jsonnet
@@ -1,0 +1,12 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'g1',
+  }
+  data: {
+    foo: 'bar',
+  },
+}
+
+

--- a/internal/eval/testdata/good-components/g2.jsonnet
+++ b/internal/eval/testdata/good-components/g2.jsonnet
@@ -1,0 +1,12 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'g2',
+  }
+  data: {
+    foo: 'bar',
+  },
+}
+
+

--- a/internal/eval/testdata/good-components/g3.jsonnet
+++ b/internal/eval/testdata/good-components/g3.jsonnet
@@ -1,0 +1,12 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'g3',
+  }
+  data: {
+    foo: 'bar',
+  },
+}
+
+

--- a/internal/eval/testdata/good-components/g4.jsonnet
+++ b/internal/eval/testdata/good-components/g4.jsonnet
@@ -1,0 +1,12 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'g4',
+  }
+  data: {
+    foo: 'bar',
+  },
+}
+
+

--- a/internal/eval/testdata/good-components/g5.jsonnet
+++ b/internal/eval/testdata/good-components/g5.jsonnet
@@ -1,0 +1,12 @@
+{
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'g5',
+  }
+  data: {
+    foo: 'bar',
+  },
+}
+
+

--- a/setup.go
+++ b/setup.go
@@ -36,12 +36,13 @@ import (
 )
 
 type gOpts struct {
-	verbose   int            // verbosity level
-	app       *model.App     // app loaded from file
-	config    vm.Config      // jsonnet VM config
-	k8sConfig *remote.Config // remote config for k8s, when needed
-	colors    bool           // colorize output
-	yes       bool           // auto-confirm
+	verbose         int            // verbosity level
+	app             *model.App     // app loaded from file
+	config          vm.Config      // jsonnet VM config
+	k8sConfig       *remote.Config // remote config for k8s, when needed
+	colors          bool           // colorize output
+	yes             bool           // auto-confirm
+	evalConcurrency int            // concurrency of component eval
 }
 
 func (g gOpts) App() *model.App {
@@ -59,6 +60,10 @@ func (g gOpts) Colorize() bool {
 
 func (g gOpts) Verbosity() int {
 	return g.verbose
+}
+
+func (g gOpts) EvalConcurrency() int {
+	return g.evalConcurrency
 }
 
 type client struct {
@@ -250,6 +255,7 @@ func setup(root *cobra.Command) {
 	root.PersistentFlags().IntVarP(&opts.verbose, "verbose", "v", 0, "verbosity level")
 	root.PersistentFlags().BoolVar(&opts.colors, "colors", false, "colorize output (set automatically if not specified)")
 	root.PersistentFlags().BoolVar(&opts.yes, "yes", false, "do not prompt for confirmation")
+	root.PersistentFlags().IntVar(&opts.evalConcurrency, "eval-concurrency", 5, "concurrency with which to evaluate components")
 
 	root.AddCommand(newOptionsCommand(root))
 	root.AddCommand(newVersionCommand())

--- a/site/content/reference/component-evaluation.md
+++ b/site/content/reference/component-evaluation.md
@@ -11,18 +11,14 @@ This works as follows:
 
 * Collect the list of files to be evaluated for the environment. This takes into account all components in the directory,
   inclusion and exclusion lists for the current environment and component filters specified on the command line.
-* Assuming this leads to 3 files, say, `c1.jsonnet`, `c2.json`, and `c3.yaml` create a jsonnet snippet as follows:
+* Assuming this leads to 3 files, say, `c1.jsonnet`, `c2.json`, and `c3.yaml` evaluate each file in its own VM in parallel
+  upto a specific concurrency.
 
-```
-local parseYaml = std.native('parseYaml');
-local parseJson = std.native('parseJson');
-{
-  'c1': import '/path/to/c1.jsonnet',
-  'c2': parseJson(importstr '/path/to/c2.json'),
-  'c3': parseYaml(importstr '/path/to/c3.yaml'),
-}
-```
-* Evaluate this snippet after setting the `qbec.io/env` extension variable to the environment name in question.
+The YAML file is parsed as: `std.native('parseYaml')(importstr '<file>')`
+
+The JSON file is parsed as: `std.native('parseJson')(importstr '<file>')`
+
+The JSONNET is evaluated as-is after setting the `qbec.io/env` extension variable to the environment name in question.
 
 ## Converting component output to Kubernetes objects
 


### PR DESCRIPTION
Previously components were evaluated by creating a megacomponent that imported
JSON, YAML and JSONNET files. This provided little to no context for errors.

We change this to evaluate every component in its own jsonnet VM.
Processing components like this sequentially  leads to 30-40% overhead so we need to evaluate
components concurrently. This is done with a default concurrency of 5. The user
can change this number using the persistent `--eval-concurrency` flag.

This change reduces the time to evaluate a large set of components _and_ produces better messages
that have the failed component name when things do not load correctly.