### PR TITLE
add experimental support to expand helm templates in qbec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 install:
-  make install get
+  make install-ci install get
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ lint:
 	go list ./... | grep -v vendor | xargs go vet
 	go list ./... | grep -v vendor | xargs golint
 
+.PHONY: install-ci
+install-ci:
+	curl -sSL -o helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz
+	tar -xvzf helm.tar.gz
+	mv linux-amd64/helm $(GOPATH)/bin/
+
 .PHONY: install
 install:
 	go get github.com/golang/dep/cmd/dep

--- a/internal/vm/helm.go
+++ b/internal/vm/helm.go
@@ -1,0 +1,100 @@
+package vm
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+)
+
+// helmOptions are options that can be passed to the helm template command as well
+// as a `thisFile` option that the caller needs to set from `std.thisFile` to make
+// relative references to charts work correctly.
+type helmOptions struct {
+	Execute      []string `json:"execute"`      // --execute option
+	KubeVersion  string   `json:"kubeVersion"`  // --kube-version option
+	Name         string   `json:"name"`         // --name option
+	NameTemplate string   `json:"nameTemplate"` // --name-template option
+	Namespace    string   `json:"namespace"`    // --namespace option
+	ThisFile     string   `json:"thisFile"`     // use supplied file as current file to resolve relative refs, should be set to std.thisFile
+	Verbose      bool     `json:"verbose"`      // print helm template command before executing it
+	//IsUpgrade    bool     `json:"isUpgrade"` // --is-upgrade option, defer adding this until implications are known,
+}
+
+// toArgs converts options to a slice of command-line args.
+func (h helmOptions) toArgs() []string {
+	var ret []string
+	if len(h.Execute) > 0 {
+		for _, e := range h.Execute {
+			ret = append(ret, "--execute", e)
+		}
+	}
+	if h.KubeVersion != "" {
+		ret = append(ret, "--kube-version", h.KubeVersion)
+	}
+	if h.Name != "" {
+		ret = append(ret, "--name", h.Name)
+	}
+	if h.NameTemplate != "" {
+		ret = append(ret, "--name-template", h.NameTemplate)
+	}
+	if h.Namespace != "" {
+		ret = append(ret, "--namespace", h.Namespace)
+	}
+	//if h.IsUpgrade {
+	//	ret = append(ret, "--is-upgrade")
+	//}
+	return ret
+}
+
+// expandHelmTemplate produces an array of objects parsed from the output of running `helm template` with
+// the supplied values and helm options.
+func expandHelmTemplate(chart string, values map[string]interface{}, options helmOptions) (out []interface{}, finalErr error) {
+	// run command from the directory containing current file or the OS temp dir if `thisFile` not specified. That is,
+	// explicitly fail to resolve relative refs unless the calling file is specified; don't let them work by happenstance.
+	workDir := os.TempDir()
+	if options.ThisFile != "" {
+		dir := filepath.Dir(options.ThisFile)
+		if !filepath.IsAbs(dir) {
+			wd, err := os.Getwd()
+			if err != nil {
+				return nil, errors.Wrap(err, "get working directory")
+			}
+			dir = filepath.Join(wd, dir)
+		}
+		workDir = dir
+	}
+
+	valueBytes, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal values to YAML")
+	}
+
+	args := append([]string{"template", chart}, options.toArgs()...)
+	args = append(args, "--values", "-")
+
+	var stdout bytes.Buffer
+	cmd := exec.Command("helm", args...)
+	cmd.Stdin = bytes.NewBuffer(valueBytes)
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = workDir
+
+	if options.Verbose {
+		fmt.Fprintf(os.Stderr, "[helm template] cd %s && helm %s\n", workDir, strings.Join(args, " "))
+	}
+
+	if err := cmd.Run(); err != nil {
+		if options.ThisFile == "" {
+			fmt.Fprintln(os.Stderr, "[WARN] helm template command failed, you may need to set the 'thisFile' option to make relative chart paths work")
+		}
+		return nil, errors.Wrap(err, "run helm template command")
+	}
+
+	return parseYAMLDocuments(bytes.NewReader(stdout.Bytes()))
+}

--- a/internal/vm/helm_test.go
+++ b/internal/vm/helm_test.go
@@ -1,0 +1,111 @@
+package vm
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelmOptions(t *testing.T) {
+	a := assert.New(t)
+	var h helmOptions
+	a.Nil(h.toArgs())
+	h = helmOptions{
+		Execute:     []string{"a.yaml", "b.yaml"},
+		KubeVersion: "1.10",
+		Name:        "foo",
+		Namespace:   "foobar",
+		ThisFile:    "/path/to/my.jsonnet",
+		Verbose:     true,
+	}
+	a.EqualValues([]string{
+		"--execute", "a.yaml",
+		"--execute", "b.yaml",
+		"--kube-version", "1.10",
+		"--name", "foo",
+		"--namespace", "foobar",
+	}, h.toArgs())
+}
+
+type cmOrSecret struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+	Data map[string]string `json:"data"`
+}
+
+func TestHelmSimpleExpand(t *testing.T) {
+	a := assert.New(t)
+	jvm := New(Config{})
+	file := "./consumer.jsonnet"
+	inputCode := `
+local expandHelmTemplate = std.native('expandHelmTemplate');
+
+expandHelmTemplate(
+    './testdata/charts/foobar',
+    {
+        foo: 'barbar',
+    },
+    {
+        namespace: 'my-ns',
+        name: 'my-name',
+        thisFile: std.thisFile,
+		verbose: true,
+    }
+)
+`
+	code, err := jvm.EvaluateSnippet(file, inputCode)
+	require.Nil(t, err)
+
+	var output []cmOrSecret
+	err = json.Unmarshal([]byte(code), &output)
+
+	require.Equal(t, 2, len(output))
+
+	sort.Slice(output, func(i, j int) bool {
+		return output[i].Kind < output[j].Kind
+	})
+
+	ob := output[0]
+	a.Equal("ConfigMap", ob.Kind)
+	a.Equal("my-ns", ob.Metadata.Namespace)
+	a.Equal("my-name", ob.Metadata.Name)
+	a.Equal("barbar", ob.Data["foo"])
+	a.Equal("baz", ob.Data["bar"])
+
+	ob = output[1]
+	a.Equal("Secret", ob.Kind)
+	a.Equal("my-ns", ob.Metadata.Namespace)
+	a.Equal("my-name", ob.Metadata.Name)
+	a.Equal("Y2hhbmdlbWUK", ob.Data["secret"])
+}
+
+func TestHelmBadRelative(t *testing.T) {
+	a := assert.New(t)
+	jvm := New(Config{})
+	file := "./consumer.jsonnet"
+	inputCode := `
+local expandHelmTemplate = std.native('expandHelmTemplate');
+
+expandHelmTemplate(
+    './testdata/charts/foobar',
+    {
+        foo: 'barbar',
+    },
+    {
+        namespace: 'my-ns',
+        name: 'my-name',
+		verbose: true,
+    }
+)
+`
+	_, err := jvm.EvaluateSnippet(file, inputCode)
+	require.NotNil(t, err)
+	a.Contains(err.Error(), "exit status 1")
+}

--- a/internal/vm/testdata/charts/foobar/Chart.yaml
+++ b/internal/vm/testdata/charts/foobar/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: foobar
+version: 1.0

--- a/internal/vm/testdata/charts/foobar/templates/config-map.yaml
+++ b/internal/vm/testdata/charts/foobar/templates/config-map.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
+data:
+  foo: {{.Values.foo}}
+  bar: {{default "baz" .Values.bar}}

--- a/internal/vm/testdata/charts/foobar/templates/secret.yaml
+++ b/internal/vm/testdata/charts/foobar/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
+data:
+  secret: {{.Values.secret}}

--- a/internal/vm/testdata/charts/foobar/values.yaml
+++ b/internal/vm/testdata/charts/foobar/values.yaml
@@ -1,0 +1,3 @@
+foo: bar
+secret: Y2hhbmdlbWUK
+

--- a/internal/vm/yaml.go
+++ b/internal/vm/yaml.go
@@ -1,0 +1,25 @@
+package vm
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func parseYAMLDocuments(reader io.Reader) ([]interface{}, error) {
+	ret := []interface{}{}
+	d := yaml.NewYAMLToJSONDecoder(reader)
+	for {
+		var doc interface{}
+		if err := d.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if doc != nil {
+			ret = append(ret, doc)
+		}
+	}
+	return ret, nil
+}

--- a/site/content/comparison-with-other-tools/_index.md
+++ b/site/content/comparison-with-other-tools/_index.md
@@ -95,7 +95,10 @@ We are not averse to adding this feature but would like to do it consciously aft
 
 ### Support for community components, prototypes, helm charts etc.
 
-Only ksonnet has these feature. In this author's opinion these features have made the ksonnet surface area large and
+Only ksonnet has these features. In this author's opinion these features have made the ksonnet surface area large and
 difficult to reason about so we have left them out. 
 
 It is probably useful to provide support for helm charts in qbec.
+
+**Update**: As of v0.6.1, qbec has experimental support to expand helm chart templates. This is implemented as a
+native function that can be called from jsonnet code.

--- a/site/content/reference/jsonnet-native-funcs.md
+++ b/site/content/reference/jsonnet-native-funcs.md
@@ -1,0 +1,73 @@
+---
+title: Jsonnet native functions
+weight: 18
+---
+
+A list of all native functions that qbec natively supports.
+
+## expandHelmTemplate
+
+The `expandHelmTemplate` function expands a helm chart and returns the resulting objects.
+This is EXPERIMENTAL in nature - the API is subject to change in a subsequent release.
+It runs the `helm template` command, assuming that the `helm` binary is already installed and
+available in the PATH.
+
+### Usage
+```
+    expandHelmTemplate("path/to/chart", 
+        { 
+            chartProperty: 'chart-value'
+        },
+        {
+            namespace: 'my-ns',
+            name: 'my-name',
+            thisFile: std.thisFile, // important
+        },
+    )
+```
+
+* The first argument is a path to a helm chart (which is usually a folder or a `.tar.gz` file).
+* The second argument is an object containing the values for the chart. This is turned into a `--values` argument to the template command.
+* The last argument is an object representing a set of options, including options to the helm command.
+
+### The options object
+
+This object supports the following keys:
+
+* `thisFile` (string) - the current file from which the function is called. Should be set to [std.thisFile](https://jsonnet.org/ref/stdlib.html#thisFile). Relative references
+   are resolved with respect to the supplied file path.
+* `namespace` (string) - the `--namespace` argument to the template command
+* `name` (string) - the `--name` argument to the template command
+* `nameTemplate` (string) - the `--name-template` argument to the template command
+* `generateName` (string) - the `--generate-name` argument to the template command
+* `execute` (array of strings) - the `--execute` argument to the template command
+* `kubeVersion` (string) - the `--kube-version` argument to the template command
+* `verbose` (bool) - print `helm template` command invocation to standard error before executing it
+
+
+## parseJson
+
+The `parseJson` function parses a JSON-encoded string and returns the corresponding object.
+
+### Usage
+```
+    local parseJson = std.native('parseJson');
+    local jsonString = '{ "hello" : "world" }';
+    
+    parseJson(jsonString) // returns the _object_ { hello: 'world' }
+```
+
+## parseYaml
+
+The `parseYaml` function parses an input string into an array of YAML documents. It _always_ returns an array
+even if there is only one YAML document in the string.
+
+### Usage
+```
+    local parseYaml = std.native('parseYaml');
+    local yamlString = importstr './path/to/yaml/file';
+    
+    parseYaml(yamlString) // returns all YAML docs as an array
+```
+
+


### PR DESCRIPTION
add a new native function called `expandHelmTemplate` that accepts a chart name,
values as a JSON object and additional helm options. Since native functions do not
have caller context, the caller needs to pass a `thisFile` value in the options
object for relative references to charts succeed. This should be set to `std.thisFile`

This allows a jsonnet caller to produce a list of objects by running `helm template`
and return them, possibly modifying them as needed.