### PR TITLE
change diff implementation to show object content on adds and deletes

### DIFF
--- a/internal/model/k8s.go
+++ b/internal/model/k8s.go
@@ -151,6 +151,9 @@ func HasSensitiveInfo(obj *unstructured.Unstructured) bool {
 // was modified from the original object. When no modifications are needed, the original object
 // is returned as-is.
 func HideSensitiveInfo(obj *unstructured.Unstructured) (*unstructured.Unstructured, bool) {
+	if obj == nil {
+		return obj, false
+	}
 	if !HasSensitiveInfo(obj) {
 		return obj, false
 	}


### PR DESCRIPTION
Previously, the diff showed a single line for adds and deletes (e.g.
'object not found on server' / 'object not found locally')

This is extremely annoying for adds where the user would typically prefer
to see the content. On the other hand, we may have made the delete case
more annoying by showing the full content of objects to be deleted.

It's still better to be consistent on both add and delete and we could
potentailly add a flag later to suppress full content of deletes.