### PR TITLE
allow a list of variables in text format to be passed in from a file

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -57,8 +57,8 @@ type runtimeError struct {
 	error
 }
 
-// newRuntimeError returns a runtime error
-func newRuntimeError(err error) error {
+// NewRuntimeError returns a runtime error
+func NewRuntimeError(err error) error {
 	return &runtimeError{
 		error: err,
 	}
@@ -78,7 +78,7 @@ func wrapError(err error) error {
 	if isUsageError(err) {
 		return err
 	}
-	return newRuntimeError(err)
+	return NewRuntimeError(err)
 }
 
 // Client encapsulates all remote operations needed for the superset of all commands.

--- a/internal/commands/common_test.go
+++ b/internal/commands/common_test.go
@@ -120,7 +120,7 @@ func TestUsageError(t *testing.T) {
 }
 
 func TestRuntimeError(t *testing.T) {
-	re := newRuntimeError(errors.New("foobar"))
+	re := NewRuntimeError(errors.New("foobar"))
 	a := assert.New(t)
 	a.True(IsRuntimeError(re))
 	a.False(isUsageError(re))

--- a/internal/vm/testdata/vars.txt
+++ b/internal/vm/testdata/vars.txt
@@ -1,0 +1,5 @@
+listVar1=l1
+
+listVar2
+
+

--- a/setup.go
+++ b/setup.go
@@ -158,7 +158,7 @@ func setup(root *cobra.Command) {
 		}
 		conf, err := vmConfigFn()
 		if err != nil {
-			return err
+			return commands.NewRuntimeError(err)
 		}
 		cmdCfg, err = cp.Config(app, conf, cfg)
 		return err


### PR DESCRIPTION
* add global option `--vm:ext-str-list` and `--vm:tla-str-list` that accept a file argument
* multiple such options are allowed on the command line
* the specified file is processed line by line with the same semantics as `--vm:ext-str`
* blank lines are ignored