### PR TITLE
add duplicate object checks and fail fast if duplicates found

### DIFF
--- a/internal/commands/apply.go
+++ b/internal/commands/apply.go
@@ -68,12 +68,11 @@ func doApply(args []string, config applyCommandConfig) error {
 	if err != nil {
 		return err
 	}
-	objects, err := filteredObjects(config.Config, env, fp)
+	client, err := config.Client(env)
 	if err != nil {
 		return err
 	}
-
-	client, err := config.Client(env)
+	objects, err := filteredObjects(config.Config, env, client.ObjectKey, fp)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -90,6 +90,7 @@ type Client interface {
 	ValidatorFor(gvk schema.GroupVersionKind) (k8smeta.Validator, error)
 	ListExtraObjects(ignore []model.K8sQbecMeta, scope remote.ListQueryConfig) ([]model.K8sQbecMeta, error)
 	Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error)
+	ObjectKey(obj model.K8sMeta) string
 }
 
 // ConfigProvider provides standard configuration available to all commands

--- a/internal/commands/component.go
+++ b/internal/commands/component.go
@@ -75,7 +75,7 @@ func doComponentList(args []string, config componentListCommandConfig) error {
 	}
 	env := args[0]
 	if config.objects {
-		objects, err := filteredObjects(config.Config, env, filterParams{})
+		objects, err := filteredObjects(config.Config, env, nil, filterParams{})
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func doComponentDiff(args []string, config componentDiffCommandConfig) error {
 	}
 
 	getObjects := func(env string) (str string, name string, err error) {
-		objs, err := filteredObjects(config.Config, env, filterParams{})
+		objs, err := filteredObjects(config.Config, env, nil, filterParams{})
 		if err != nil {
 			return
 		}

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -53,7 +53,7 @@ func doDelete(args []string, config deleteCommandConfig) error {
 
 	var deletions []model.K8sQbecMeta
 	if config.useLocal {
-		objects, err := filteredObjects(config.Config, env, fp)
+		objects, err := filteredObjects(config.Config, env, client.ObjectKey, fp)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -275,12 +275,12 @@ func doDiff(args []string, config diffCommandConfig) error {
 		return err
 	}
 
-	objects, err := filteredObjects(config.Config, env, fp)
+	client, err := config.Client(env)
 	if err != nil {
 		return err
 	}
 
-	client, err := config.Client(env)
+	objects, err := filteredObjects(config.Config, env, client.ObjectKey, fp)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -103,7 +103,15 @@ func doShow(args []string, config showCommandConfig) error {
 	if err != nil {
 		return err
 	}
-	objects, err := filteredObjects(config.Config, env, fp)
+
+	// shallow duplicate check
+	keyFunc := func(obj model.K8sMeta) string {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		ns := obj.GetNamespace()
+		return fmt.Sprintf("%s:%s:%s:%s", gvk.Group, gvk.Kind, ns, obj.GetName())
+	}
+
+	objects, err := filteredObjects(config.Config, env, keyFunc, fp)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/show_test.go
+++ b/internal/commands/show_test.go
@@ -199,6 +199,7 @@ func TestShowNegative(t *testing.T) {
 		name     string
 		args     []string
 		asserter func(s *scaffold, err error)
+		dir      string
 	}{
 		{
 			name: "no env",
@@ -254,10 +255,20 @@ func TestShowNegative(t *testing.T) {
 				a.Equal(`cannot include as well as exclude kinds, specify one or the other`, err.Error())
 			},
 		},
+		{
+			name: "duplicate objects",
+			args: []string{"show", "dev"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(IsRuntimeError(err))
+				a.Equal(`duplicate objects ConfigMap cm1 (component: x) and ConfigMap cm1 (component: y)`, err.Error())
+			},
+			dir: "testdata/dups",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := newScaffold(t)
+			s := newCustomScaffold(t, test.dir)
 			defer s.reset()
 			err := s.executeCommand(test.args...)
 			require.NotNil(t, err)

--- a/internal/commands/testdata/dups/components/x.yaml
+++ b/internal/commands/testdata/dups/components/x.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  foo: bar
+
+

--- a/internal/commands/testdata/dups/components/y.yaml
+++ b/internal/commands/testdata/dups/components/y.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+data:
+  foo: bar

--- a/internal/commands/testdata/dups/qbec.yaml
+++ b/internal/commands/testdata/dups/qbec.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: qbec.io/v1alpha1
+kind: App
+metadata:
+  name: app2
+spec:
+  environments:
+    dev:
+      server: https://dev-server
+      defaultNamespace: kube-system

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -227,8 +227,11 @@ func (s *scaffold) outputStats() map[string]interface{} {
 	return data.Stats
 }
 
-func newScaffold(t *testing.T) *scaffold {
-	reset := setPwd(t, "../../examples/test-app")
+func newCustomScaffold(t *testing.T, dir string) *scaffold {
+	if dir == "" {
+		dir = "../../examples/test-app"
+	}
+	reset := setPwd(t, dir)
 	app, err := model.NewApp("qbec.yaml", "")
 	require.Nil(t, err)
 	out := bytes.NewBuffer(nil)
@@ -266,4 +269,9 @@ func newScaffold(t *testing.T) *scaffold {
 		sio.EnableColors = oldColors
 	}
 	return s
+
+}
+
+func newScaffold(t *testing.T) *scaffold {
+	return newCustomScaffold(t, "")
 }

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -49,6 +49,7 @@ type client struct {
 	validatorFunc func(gvk schema.GroupVersionKind) (k8smeta.Validator, error)
 	listExtraFunc func(ignore []model.K8sQbecMeta, scope remote.ListQueryConfig) ([]model.K8sQbecMeta, error)
 	deleteFunc    func(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error)
+	objectKeyFunc func(obj model.K8sMeta) string
 }
 
 func (c *client) DisplayName(o model.K8sMeta) string {
@@ -98,6 +99,13 @@ func (c *client) Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, err
 		return c.deleteFunc(obj, dryRun)
 	}
 	return nil, errors.New("not implemented")
+}
+
+func (c *client) ObjectKey(obj model.K8sMeta) string {
+	if c.objectKeyFunc != nil {
+		return c.objectKeyFunc(obj)
+	}
+	return fmt.Sprintf("%s:%s:%s:%s", obj.GetObjectKind().GroupVersionKind().Group, obj.GetKind(), obj.GetNamespace(), obj.GetName())
 }
 
 func setPwd(t *testing.T, dir string) func() {

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -155,11 +155,11 @@ func doValidate(args []string, config validateCommandConfig) error {
 	if err != nil {
 		return err
 	}
-	objects, err := filteredObjects(config.Config, env, fp)
+	client, err := config.Client(env)
 	if err != nil {
 		return err
 	}
-	client, err := config.Client(env)
+	objects, err := filteredObjects(config.Config, env, client.ObjectKey, fp)
 	if err != nil {
 		return err
 	}

--- a/internal/remote/collection.go
+++ b/internal/remote/collection.go
@@ -51,6 +51,7 @@ func (b *basicObject) Environment() string                             { return 
 
 type collectMetadata interface {
 	IsNamespaced(gvk schema.GroupVersionKind) (bool, error)
+	objectNamespace(obj model.K8sMeta) string
 	canonicalGroupVersionKind(in schema.GroupVersionKind) (schema.GroupVersionKind, error)
 }
 
@@ -117,18 +118,7 @@ func (c *collection) add(object model.K8sQbecMeta) error {
 	if err != nil {
 		return err
 	}
-	namespaced, err := c.meta.IsNamespaced(canonicalGVK)
-	if err != nil {
-		return err
-	}
-	ns := object.GetNamespace()
-	if namespaced {
-		if ns == "" {
-			ns = c.defaultNs
-		}
-	} else {
-		ns = ""
-	}
+	ns := c.meta.objectNamespace(object)
 	key := objectKey{
 		gvk:       canonicalGVK,
 		namespace: ns,


### PR DESCRIPTION
currently qbec doesn't perform any duplicate checking which can
cause indeterministic behavior based on which version of the
object "wins" the race for backend updates.

This commit introduces a deep duplicate check for commands
that have access to cluster metadata and a shallow version
for the show command that typically doesn't need cluster metadata.

The deep check will detect duplicates like 2 deployments with the same
namespace and name that are marked, say, extensions/v1beta1 and
apps/v1 respectively.