### PR TITLE
improve shell integration: add env list|vars commands

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -105,6 +105,7 @@ func Setup(root *cobra.Command, cp ConfigProvider) {
 	root.AddCommand(newDeleteCommand(cp))
 	root.AddCommand(newComponentCommand(cp))
 	root.AddCommand(newParamCommand(cp))
+	root.AddCommand(newEnvCommand(cp))
 	root.AddCommand(newInitCommand())
 }
 

--- a/internal/commands/env.go
+++ b/internal/commands/env.go
@@ -1,0 +1,193 @@
+/*
+   Copyright 2019 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+)
+
+func newEnvCommand(cp ConfigProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env <subcommand>",
+		Short: "environment lists and details",
+	}
+	cmd.AddCommand(newEnvListCommand(cp), newEnvVarsCommand(cp))
+	return cmd
+}
+
+type envListCommandConfig struct {
+	*Config
+	format string
+}
+
+func newEnvListCommand(cp ConfigProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list [-o <format>]",
+		Short:   "list all environments in short, json or yaml format",
+		Example: envListExamples(),
+	}
+
+	config := envListCommandConfig{}
+	cmd.Flags().StringVarP(&config.format, "format", "o", "", "use json|yaml to display machine readable output")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		config.Config = cp()
+		return wrapError(doEnvList(args, config))
+	}
+	return cmd
+}
+
+type displayEnv struct {
+	Name             string `json:"name"`
+	Server           string `json:"server"`
+	DefaultNamespace string `json:"defaultNamespace"`
+}
+
+type displayEnvList struct {
+	Environments []displayEnv `json:"environments"`
+}
+
+func listEnvironments(config envListCommandConfig) error {
+	app := config.Config.App()
+	var list []displayEnv
+	for name, obj := range app.Environments() {
+		defNs := obj.DefaultNamespace
+		if defNs == "" {
+			defNs = "default"
+		}
+		list = append(list, displayEnv{
+			Name:             name,
+			Server:           obj.Server,
+			DefaultNamespace: defNs,
+		})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+
+	wrapper := displayEnvList{list}
+	w := config.Stdout()
+
+	switch config.format {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(wrapper)
+	case "yaml":
+		b, _ := yaml.Marshal(wrapper)
+		_, _ = w.Write(b)
+	case "":
+		for _, e := range list {
+			fmt.Fprintln(w, e.Name)
+		}
+	default:
+		return newUsageError(fmt.Sprintf("listEnvironments: unsupported format %q", config.format))
+	}
+	return nil
+}
+
+func doEnvList(args []string, config envListCommandConfig) error {
+	if len(args) != 0 {
+		return newUsageError("extra arguments specified")
+	}
+	return listEnvironments(config)
+}
+
+func newEnvVarsCommand(cp ConfigProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "vars [-o <format>] <env>",
+		Short:   "print variables for kubeconfig, context and cluster for an environment",
+		Example: envVarsExamples(),
+	}
+
+	config := envVarsCommandConfig{}
+	cmd.Flags().StringVarP(&config.format, "format", "o", "", "use json|yaml to display machine readable output")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		config.Config = cp()
+		return wrapError(doEnvVars(args, config))
+	}
+	return cmd
+}
+
+type envVarsCommandConfig struct {
+	*Config
+	format string
+}
+
+func doEnvVars(args []string, config envVarsCommandConfig) error {
+	if len(args) != 1 {
+		return newUsageError("exactly one environment required")
+	}
+	if _, ok := config.app.Environments()[args[0]]; !ok {
+		return fmt.Errorf("invalid environment: %q", args[0])
+	}
+	return environmentVars(args[0], config)
+}
+
+func environmentVars(name string, config envVarsCommandConfig) error {
+	attrs, err := config.KubeAttributes(name)
+	if err != nil {
+		return err
+	}
+	w := config.Stdout()
+	switch config.format {
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(attrs)
+	case "yaml":
+		b, _ := yaml.Marshal(attrs)
+		_, _ = w.Write(b)
+	case "":
+		var kcArgs []string
+		addArg := func(name, value string) {
+			if value != "" {
+				kcArgs = append(kcArgs, fmt.Sprintf(`--%s=%s`, name, value))
+			}
+		}
+		addArg("context", attrs.Context)
+		addArg("cluster", attrs.Cluster)
+		addArg("namespace", attrs.Namespace)
+
+		var lines []string
+		var vars []string
+		addLine := func(name, value string) {
+			lines = append(lines, fmt.Sprintf(`%s='%s'`, name, value))
+			vars = append(vars, name)
+		}
+		addLine("KUBECONFIG", attrs.ConfigFile)
+		addLine("KUBE_CLUSTER", attrs.Cluster)
+		addLine("KUBE_CONTEXT", attrs.Context)
+		addLine("KUBE_NAMESPACE", attrs.Namespace)
+		addLine("KUBECTL_ARGS", strings.Join(kcArgs, " "))
+
+		for _, l := range lines {
+			fmt.Fprintf(w, "%s;\n", l)
+		}
+		fmt.Fprintf(w, "export %s\n", strings.Join(vars, " "))
+	default:
+		return newUsageError(fmt.Sprintf("environmentVars: unsupported format %q", config.format))
+	}
+	return nil
+}

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -1,0 +1,163 @@
+/*
+   Copyright 2019 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvListBasic(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "list")
+	require.Nil(t, err)
+	lines := strings.Split(strings.Trim(s.stdout(), "\n"), "\n")
+	a := assert.New(t)
+	require.Equal(t, 2, len(lines))
+	a.Equal("dev", lines[0])
+	a.Equal("prod", lines[1])
+}
+
+func TestEnvListYAML(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "list", "-o", "yaml")
+	require.Nil(t, err)
+	out, err := s.yamlOutput()
+	require.Nil(t, err)
+	assert.True(t, len(out) > 0)
+}
+
+func TestEnvListJSON(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "list", "-o", "json")
+	require.Nil(t, err)
+	var data interface{}
+	err = s.jsonOutput(&data)
+	require.Nil(t, err)
+}
+
+func TestEnvVarsBasic(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "vars", "dev")
+	require.Nil(t, err)
+	s.assertOutputLineMatch(regexp.MustCompile(`KUBECONFIG='kube.config';`))
+	s.assertOutputLineMatch(regexp.MustCompile(`KUBE_CLUSTER='dev.server.com';`))
+	s.assertOutputLineMatch(regexp.MustCompile(`KUBE_CONTEXT='foo'`))
+	s.assertOutputLineMatch(regexp.MustCompile(`KUBE_NAMESPACE='my-ns';`))
+	s.assertOutputLineMatch(regexp.MustCompile(`export KUBECONFIG KUBE_CLUSTER KUBE_CONTEXT KUBE_NAMESPACE KUBECTL_ARGS`))
+}
+
+func TestEnvVarsYAML(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "vars", "dev", "-o", "yaml")
+	require.Nil(t, err)
+	out, err := s.yamlOutput()
+	require.Nil(t, err)
+	assert.True(t, len(out) > 0)
+}
+
+func TestEnvVarsJSON(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("env", "vars", "dev", "-o", "json")
+	require.Nil(t, err)
+	var data interface{}
+	err = s.jsonOutput(&data)
+	require.Nil(t, err)
+}
+
+func TestEnvNegative(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		asserter func(s *scaffold, err error)
+	}{
+		{
+			name: "list with env",
+			args: []string{"env", "list", "dev"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(isUsageError(err))
+				a.Equal("extra arguments specified", err.Error())
+			},
+		},
+		{
+			name: "list bad format",
+			args: []string{"env", "list", "-o", "table"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(isUsageError(err))
+				a.Equal(`listEnvironments: unsupported format "table"`, err.Error())
+			},
+		},
+		{
+			name: "vars no env",
+			args: []string{"env", "vars"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(isUsageError(err))
+				a.Equal(`exactly one environment required`, err.Error())
+			},
+		},
+		{
+			name: "vars two envs",
+			args: []string{"env", "vars", "dev", "prod"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(isUsageError(err))
+				a.Equal(`exactly one environment required`, err.Error())
+			},
+		},
+		{
+			name: "vars bad env",
+			args: []string{"env", "vars", "foo"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(isUsageError(err))
+				a.Equal(`invalid environment: "foo"`, err.Error())
+			},
+		},
+		{
+			name: "vars bad format",
+			args: []string{"env", "vars", "-o", "table", "dev"},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.True(isUsageError(err))
+				a.Equal(`environmentVars: unsupported format "table"`, err.Error())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newScaffold(t)
+			defer s.reset()
+			err := s.executeCommand(test.args...)
+			require.NotNil(t, err)
+			test.asserter(s, err)
+		})
+	}
+}

--- a/internal/commands/examples.go
+++ b/internal/commands/examples.go
@@ -120,3 +120,17 @@ func paramDiffExamples() string {
 		newExample("param diff dev prod", "show differences in parameter values  between dev and prod"),
 	)
 }
+
+func envListExamples() string {
+	return exampleHelp(
+		newExample("env list", "list all environment names, one per line in sorted order"),
+		newExample("env list -o json", "list all enviroments in JSON format, (use -o yaml for YAML)"),
+	)
+}
+
+func envVarsExamples() string {
+	return exampleHelp(
+		newExample("env vars <env>", "print kubernetes variables for env in eval format, run as `eval $(qbec env vars env)`"),
+		newExample("env vars -o json", "print kubernetes variables for env in JSON format, (use -o yaml for YAML)"),
+	)
+}

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -227,13 +227,20 @@ func newCustomScaffold(t *testing.T, dir string) *scaffold {
 
 	c := &client{}
 	clientProvider := func(env string) (Client, error) { return c, nil }
-
+	attrsProvider := func(env string) (*remote.KubeAttributes, error) {
+		return &remote.KubeAttributes{
+			Context:    "foo",
+			ConfigFile: "kube.config",
+			Namespace:  "my-ns",
+			Cluster:    "dev.server.com",
+		}, nil
+	}
 	cp := ConfigFactory{
 		Stdout:      out,
 		SkipConfirm: true,
 		Colors:      false,
 	}
-	config, err := cp.internalConfig(app, vm.Config{}, clientProvider)
+	config, err := cp.internalConfig(app, vm.Config{}, clientProvider, attrsProvider)
 	require.Nil(t, err)
 
 	cmd := &cobra.Command{

--- a/internal/model/app.go
+++ b/internal/model/app.go
@@ -264,6 +264,10 @@ func (a *App) ComponentsForEnvironment(env string, includes, excludes []string) 
 	return toList(subret), nil
 }
 
+func (a *App) Environments() map[string]Environment {
+	return a.inner.Spec.Environments
+}
+
 // DeclaredVars returns defaults for all declared external variables, keyed by variable name.
 func (a *App) DeclaredVars() map[string]interface{} {
 	ret := map[string]interface{}{}


### PR DESCRIPTION
Add 2 new commands `env list` and `env vars`.

The first prints a list of known environments. This is useful for
scripts that need to iterate over qbec environments.

The second prints environment variables in eval format that can be
use to run kubectl or other programs with a specific kubeconfig,
context, cluster and namespace that qbec would derive for a
specific environment.