### PR TITLE
propagate --clean flag for postprocessor use

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -149,6 +149,7 @@ type Config struct {
 	stdin           io.Reader         // standard input
 	stdout          io.Writer         // standard output
 	stderr          io.Writer         // standard error
+	cleanEvalMode   bool              // clean mode for eval
 }
 
 // init checks variables and sets up defaults. In strict mode, it requires all variables
@@ -244,6 +245,7 @@ func (c Config) EvalContext(env string) eval.Context {
 		Verbose:         c.Verbosity() > 1,
 		Concurrency:     c.EvalConcurrency(),
 		PostProcessFile: c.App().PostProcessor(),
+		CleanMode:       c.cleanEvalMode,
 	}
 }
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -90,6 +90,7 @@ type Context struct {
 	Verbose         bool         // show generated code
 	Concurrency     int          // concurrent components to evaluate, default 5
 	PostProcessFile string       // the file that contains post-processing code for all objects
+	CleanMode       bool         // whether clean mode is enabled
 }
 
 func (c Context) baseVMConfig(tlas []string) vm.Config {
@@ -97,10 +98,15 @@ func (c Context) baseVMConfig(tlas []string) vm.Config {
 	if fn == nil {
 		fn = defaultFunc
 	}
+	cm := "off"
+	if c.CleanMode {
+		cm = "on"
+	}
 	cfg := fn(tlas).WithVars(map[string]string{
 		model.QbecNames.EnvVarName:       c.Env,
 		model.QbecNames.TagVarName:       c.Tag,
 		model.QbecNames.DefaultNsVarName: c.DefaultNs,
+		model.QbecNames.CleanModeVarName: cm,
 	})
 	return cfg
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -97,6 +97,29 @@ func TestEvalComponents(t *testing.T) {
 	a.Equal("#svc2", obj.ToUnstructured().GetAnnotations()["slack"])
 }
 
+func TestEvalComponentsClean(t *testing.T) {
+	objs, err := Components([]model.Component{
+		{
+			Name: "a",
+			File: "testdata/components/a.json",
+		},
+	}, Context{Env: "dev", CleanMode: true, PostProcessFile: "testdata/components/pp/pp.jsonnet"})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(objs))
+	a := assert.New(t)
+
+	obj := objs[0]
+	a.Equal("a", obj.Component())
+	a.Equal("dev", obj.Environment())
+	a.Equal("", obj.GroupVersionKind().Group)
+	a.Equal("v1", obj.GroupVersionKind().Version)
+	a.Equal("ConfigMap", obj.GroupVersionKind().Kind)
+	a.Equal("", obj.GetNamespace())
+	a.Equal("json-config-map", obj.GetName())
+	a.Equal("", obj.ToUnstructured().GetAnnotations()["team"])
+	a.Equal("", obj.ToUnstructured().GetAnnotations()["slack"])
+}
+
 func TestEvalComponentsEdges(t *testing.T) {
 	goodComponents := []model.Component{
 		{Name: "g1", File: "testdata/good-components/g1.jsonnet"},

--- a/internal/eval/testdata/components/pp/pp.jsonnet
+++ b/internal/eval/testdata/components/pp/pp.jsonnet
@@ -1,3 +1,3 @@
 local annotations = import './annotations.libsonnet';
 
-function (object) object  { metadata +: { annotations +: annotations } }
+function (object) object + if std.extVar('qbec.io/cleanMode') == 'on' then {} else { metadata +: { annotations +: annotations } }

--- a/internal/model/external-names.go
+++ b/internal/model/external-names.go
@@ -30,6 +30,7 @@ var QbecNames = struct {
 	EnvVarName          string // the name of the external variable that has the environment name
 	TagVarName          string // the name of the external variable that has the tag name
 	DefaultNsVarName    string // the name of the external variable that has the default namespace
+	CleanModeVarName    string // name of external variable that has the indicator for clean mode
 }{
 	ApplicationLabel:    QBECMetadataPrefix + "application",
 	TagLabel:            QBECMetadataPrefix + "tag",
@@ -40,4 +41,5 @@ var QbecNames = struct {
 	EnvVarName:          QBECMetadataPrefix + "env",
 	TagVarName:          QBECMetadataPrefix + "tag",
 	DefaultNsVarName:    QBECMetadataPrefix + "defaultNs",
+	CleanModeVarName:    QBECMetadataPrefix + "cleanMode",
 }


### PR DESCRIPTION
add a new ext var called `qbec.io/cleanMode` that is set to "on" or "off".
It is only ever set to "on" for the `show --clean` command. This can be
used by a post-processor to refrain from adding non-functional labels
and metadata to provide a "real clean" experience for the developer.