### PR TITLE
fix pristine object retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .DS_Store
 tmp/
 vendor/

--- a/internal/remote/pristine_test.go
+++ b/internal/remote/pristine_test.go
@@ -1,0 +1,210 @@
+package remote
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/splunk/qbec/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestZipRoundTrip(t *testing.T) {
+	text := `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna 
+aliqua. Tellus pellentesque eu tincidunt tortor aliquam nulla facilisi cras fermentum. Vitae tortor condimentum lacinia 
+quis vel eros donec. Sem viverra aliquet eget sit amet tellus cras. Faucibus nisl tincidunt eget nullam non nisi est. 
+Amet massa vitae tortor condimentum lacinia quis vel eros donec. In nulla posuere sollicitudin aliquam ultrices. 
+Dolor morbi non arcu risus. Netus et malesuada fames ac turpis egestas. Sit amet consectetur adipiscing elit 
+pellentesque habitant morbi tristique. Vestibulum morbi blandit cursus risus at ultrices. Integer vitae justo eget 
+magna. Lectus nulla at volutpat diam ut venenatis tellus in metus. Tellus pellentesque eu tincidunt tortor aliquam 
+nulla facilisi. Blandit libero volutpat sed cras ornare arcu. Turpis nunc eget lorem dolor sed viverra ipsum nunc 
+aliquet. Et sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Nascetur ridiculus mus mauris 
+vitae ultricies leo integer malesuada. Quam adipiscing vitae proin sagittis. Faucibus interdum posuere lorem ipsum.
+`
+	data := map[string]interface{}{
+		"foo":  "bar",
+		"text": text,
+	}
+	zipped, err := zipData(data)
+	require.Nil(t, err)
+	ret, err := unzipData(zipped)
+	require.Nil(t, err)
+	a := assert.New(t)
+	a.Equal(2, len(ret))
+	a.Equal("bar", ret["foo"])
+	a.Equal(text, ret["text"])
+}
+
+func TestUnzipNegative(t *testing.T) {
+	a := assert.New(t)
+
+	_, err := unzipData("xxx")
+	require.NotNil(t, err)
+	a.Contains(err.Error(), "illegal base64 data")
+
+	_, err = unzipData(base64.StdEncoding.EncodeToString([]byte("xxx")))
+	require.NotNil(t, err)
+	a.Contains(err.Error(), "unexpected EOF")
+}
+
+func loadFile(t *testing.T, file string) *unstructured.Unstructured {
+	b, err := ioutil.ReadFile(filepath.Join("testdata", "pristine", file))
+	require.Nil(t, err)
+	var data map[string]interface{}
+	err = yaml.Unmarshal(b, &data)
+	require.Nil(t, err)
+	return &unstructured.Unstructured{Object: data}
+}
+
+func testPristineReader(t *testing.T, useFallback bool) {
+	tests := []struct {
+		name     string
+		file     string
+		mod      func(obj *unstructured.Unstructured)
+		asserter func(t *testing.T, obj *unstructured.Unstructured, source string)
+	}{
+		{
+			file: "input.yaml",
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				if !useFallback {
+					a.Equal("", source)
+					a.Nil(obj)
+					return
+				}
+				a.Equal("fallback - live object with some attributes removed", source)
+				a.NotNil(obj)
+
+			},
+		},
+		{
+			file: "kc-created.yaml",
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				if !useFallback {
+					a.Equal("", source)
+					a.Nil(obj)
+					return
+				}
+				a.Equal("fallback - live object with some attributes removed", source)
+				a.NotNil(obj)
+				a.Equal("", obj.GetResourceVersion())
+				a.Equal("", obj.GetSelfLink())
+				a.EqualValues("", obj.GetUID())
+				a.EqualValues(0, obj.GetGeneration())
+				a.Nil(obj.Object["status"])
+			},
+		},
+		{
+			file: "kc-applied.yaml",
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				a.Equal("kubectl annotation", source)
+				a.NotNil(obj)
+				a.NotEqual("", obj.GetAnnotations()[kubectlLastConfig])
+			},
+		},
+		{
+			name: "kc-bad.yaml",
+			file: "kc-applied.yaml",
+			mod: func(obj *unstructured.Unstructured) {
+				anns := obj.GetAnnotations()
+				anns[kubectlLastConfig] += "XXX"
+				obj.SetAnnotations(anns)
+			},
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				if !useFallback {
+					a.Equal("", source)
+					a.Nil(obj)
+					return
+				}
+				a.Equal("fallback - live object with some attributes removed", source)
+				a.NotNil(obj)
+			},
+		},
+		{
+			file: "qbec-applied.yaml",
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				a.Equal("qbec annotation", source)
+				a.NotNil(obj)
+				a.Equal("", obj.GetAnnotations()[kubectlLastConfig])
+				a.Equal("", obj.GetAnnotations()[model.QbecNames.PristineAnnotation])
+			},
+		},
+		{
+			name: "qbec-bad.yaml",
+			file: "qbec-applied.yaml",
+			mod: func(obj *unstructured.Unstructured) {
+				anns := obj.GetAnnotations()
+				anns[model.QbecNames.PristineAnnotation] += "XXX"
+				obj.SetAnnotations(anns)
+			},
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				if !useFallback {
+					a.Equal("", source)
+					a.Nil(obj)
+					return
+				}
+				a.Equal("fallback - live object with some attributes removed", source)
+				a.NotNil(obj)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		name := test.name
+		if name == "" {
+			name = test.file
+		}
+		t.Run(name, func(t *testing.T) {
+			obj := loadFile(t, test.file)
+			if test.mod != nil {
+				test.mod(obj)
+			}
+			var pristine *unstructured.Unstructured
+			var source string
+			if useFallback {
+				pristine, source = GetPristineVersionForDiff(obj)
+			} else {
+				pristine, source = getPristineVersion(obj, false)
+			}
+			test.asserter(t, pristine, source)
+		})
+	}
+}
+
+func TestPristineReaderFallback(t *testing.T) {
+	testPristineReader(t, true)
+}
+
+func TestPristineReaderNoFallback(t *testing.T) {
+	testPristineReader(t, false)
+}
+
+func TestCreateFromPristine(t *testing.T) {
+	un := loadFile(t, "input.yaml")
+	p := qbecPristine{}
+	obj := model.NewK8sLocalObject(un.Object, "app", "", "comp1", "dev")
+	ret, err := p.createFromPristine(obj)
+	require.Nil(t, err)
+	a := assert.New(t)
+	eLabels := obj.ToUnstructured().GetLabels()
+	aLabels := ret.ToUnstructured().GetLabels()
+	a.EqualValues(eLabels, aLabels)
+	eAnnotations := obj.ToUnstructured().GetAnnotations()
+	aAnnotations := ret.ToUnstructured().GetAnnotations()
+	pValue := aAnnotations[model.QbecNames.PristineAnnotation]
+	delete(aAnnotations, model.QbecNames.PristineAnnotation)
+	a.EqualValues(eAnnotations, aAnnotations)
+	pObj, err := unzipData(pValue)
+	require.Nil(t, err)
+	a.EqualValues(un.Object, pObj)
+}

--- a/internal/remote/testdata/pristine/input.yaml
+++ b/internal/remote/testdata/pristine/input.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+

--- a/internal/remote/testdata/pristine/kc-applied.yaml
+++ b/internal/remote/testdata/pristine/kc-applied.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"storage","namespace":"istio-test"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Mi"}}}}
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/aws-ebs
+  creationTimestamp: 2019-07-28T17:39:09Z
+  finalizers:
+  - kubernetes.io/pvc-protection
+  name: storage
+  namespace: istio-test
+  resourceVersion: "41064362"
+  selfLink: /api/v1/namespaces/istio-test/persistentvolumeclaims/storage
+  uid: 9b0bfad7-b15e-11e9-bd54-0ace00d90692
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+  storageClassName: gp2
+  volumeName: pvc-9b0bfad7-b15e-11e9-bd54-0ace00d90692
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound

--- a/internal/remote/testdata/pristine/kc-created.yaml
+++ b/internal/remote/testdata/pristine/kc-created.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/aws-ebs
+  creationTimestamp: 2019-07-28T17:39:09Z
+  finalizers:
+  - kubernetes.io/pvc-protection
+  name: storage
+  namespace: istio-test
+  resourceVersion: "41064230"
+  selfLink: /api/v1/namespaces/istio-test/persistentvolumeclaims/storage
+  uid: 9b0bfad7-b15e-11e9-bd54-0ace00d90692
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+  storageClassName: gp2
+  volumeName: pvc-9b0bfad7-b15e-11e9-bd54-0ace00d90692
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound

--- a/internal/remote/testdata/pristine/qbec-applied.yaml
+++ b/internal/remote/testdata/pristine/qbec-applied.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    qbec.io/component: storage
+    qbec.io/last-applied: H4sIAAAAAAAA/1SOMWvDQAxG9/6Mb3ZTst7aObR0SIfSQTmLVuROupzkQDH+78UOBDJKPN73ZlCTI3cXUyRc9xhwFh2R8L5+PVjjaGWq/FpIKgZUDhopCGkGqVpQiKmv5+XEeSf2kq02U9ZAgod1+mEsAwqduDyA1FqRvAmQcO7iv0q6Ew+x52APx3CHWa/STevNe2Naob/96laq/LjmjfPWmDO7H2xkR/rCB9P42SX4TTPje0Bnt6ln3sI6X6ZtNs13V8L+IFiWZXn6BwAA//8BAAD//5YWR/4vAQAA
+    volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/aws-ebs
+  creationTimestamp: 2019-07-28T17:39:09Z
+  finalizers:
+  - kubernetes.io/pvc-protection
+  labels:
+    qbec.io/application: krishnan.istio-tests
+    qbec.io/environment: istio-play1
+  name: storage
+  namespace: istio-test
+  resourceVersion: "41064645"
+  selfLink: /api/v1/namespaces/istio-test/persistentvolumeclaims/storage
+  uid: 9b0bfad7-b15e-11e9-bd54-0ace00d90692
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+  storageClassName: gp2
+  volumeName: pvc-9b0bfad7-b15e-11e9-bd54-0ace00d90692
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound


### PR DESCRIPTION
The pristine reader is supposed to return a pristine object from qbec annotations.
When this is not found, it is either supposed to return a live object for diffs
or an empty object for patches. It was currently returning the live object for both
causing the patch to try and remove fields set by kubernetes. This is fixed by
correctly honoring the includeFallback flag.

Also, use kubectl annotations as a pristine source when qbec annotations are not found.
In this case also add the original k8s annotation into the deserialized object
because from qbec's viewpoint, this is a diff that needs to be reconciled. In other
words, by doing this, we will make qbec delete the original kubectl annotation
and "adopt" the object correctly.