### PR TITLE
allow custom qbec processing with qbec-specific annotations on objects

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -90,7 +90,7 @@ type Client interface {
 	Sync(obj model.K8sLocalObject, opts remote.SyncOptions) (*remote.SyncResult, error)
 	ValidatorFor(gvk schema.GroupVersionKind) (k8smeta.Validator, error)
 	ListObjects(scope remote.ListQueryConfig) (remote.Collection, error)
-	Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error)
+	Delete(model.K8sMeta, remote.DeleteOptions) (*remote.SyncResult, error)
 	ObjectKey(obj model.K8sMeta) string
 	ResourceInterface(obj schema.GroupVersionKind, namespace string) (dynamic.ResourceInterface, error)
 }

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/chzyer/readline"
@@ -372,7 +373,24 @@ func (c Config) Confirm(context string) error {
 	}
 }
 
-// SortConfig returns the sort configuration.
+func ordering(item model.K8sQbecMeta) int {
+	a := item.GetAnnotations()
+	if a == nil {
+		return 0
+	}
+	v := a[model.QbecNames.Directives.ApplyOrder]
+	if v == "" {
+		return 0
+	}
+	val, err := strconv.Atoi(v)
+	if err != nil {
+		sio.Warnf("invalid apply order directive '%s' for %s, ignored\n", v, model.NameForDisplay(item))
+		return 0
+	}
+	return val
+}
+
+// sortConfig returns the sort configuration.
 func sortConfig(provider objsort.Namespaced) objsort.Config {
 	return objsort.Config{
 		NamespacedIndicator: func(gvk schema.GroupVersionKind) (bool, error) {
@@ -382,5 +400,6 @@ func sortConfig(provider objsort.Namespaced) objsort.Config {
 			}
 			return ret, nil
 		},
+		OrderingProvider: ordering,
 	}
 }

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/splunk/qbec/internal/model"
 	"github.com/splunk/qbec/internal/remote"
 	"github.com/splunk/qbec/internal/vm"
@@ -154,4 +155,59 @@ func TestConfigConfirm(t *testing.T) {
 	err = cfg.Confirm("we will destroy you")
 	require.NotNil(t, err)
 	a.Equal("canceled", err.Error())
+}
+
+func TestOrdering(t *testing.T) {
+	simple := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+data:
+  foo: bar
+`
+	good := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  annotations:
+    directives.qbec.io/apply-order: "1000"
+data:
+  foo: bar
+`
+	bad := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+  annotations:
+    directives.qbec.io/apply-order: "foo"
+data:
+  foo: bar
+`
+	unmarshal := func(s string) map[string]interface{} {
+		ret := map[string]interface{}{}
+		err := yaml.Unmarshal([]byte(s), &ret)
+		if err != nil {
+			panic(err)
+		}
+		return ret
+	}
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		expected int
+	}{
+		{"no annotations", unmarshal(simple), 0},
+		{"bad", unmarshal(bad), 0},
+		{"good", unmarshal(good), 1000},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ret := ordering(model.NewK8sLocalObject(test.data, "app", "tag", "component", "env"))
+			assert.Equal(t, test.expected, ret)
+		})
+	}
 }

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -100,10 +100,15 @@ func doDelete(args []string, config deleteCommandConfig) error {
 	}
 
 	var stats applyStats
+	dp := newDeletePolicy(client.IsNamespaced, config.App().DefaultNamespace(env))
+	delOpts := remote.DeleteOptions{
+		DryRun:          config.dryRun,
+		DisableDeleteFn: dp.disableDelete,
+	}
 	for i := len(deletions) - 1; i >= 0; i-- {
 		ob := deletions[i]
 		name := client.DisplayName(ob)
-		res, err := client.Delete(ob, config.dryRun)
+		res, err := client.Delete(ob, delOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/delete_test.go
+++ b/internal/commands/delete_test.go
@@ -31,7 +31,7 @@ func TestDeleteRemote(t *testing.T) {
 	d := &dg{cmValue: "baz", secretValue: "baz"}
 	s.client.getFunc = d.get
 	s.client.listFunc = stdLister
-	s.client.deleteFunc = func(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error) {
+	s.client.deleteFunc = func(obj model.K8sMeta, opts remote.DeleteOptions) (*remote.SyncResult, error) {
 		return &remote.SyncResult{Type: remote.SyncDeleted}, nil
 	}
 	err := s.executeCommand("delete", "dev")
@@ -47,7 +47,7 @@ func TestDeleteRemoteComponentFilter(t *testing.T) {
 	d := &dg{cmValue: "baz", secretValue: "baz"}
 	s.client.getFunc = d.get
 	s.client.listFunc = stdLister
-	s.client.deleteFunc = func(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error) {
+	s.client.deleteFunc = func(obj model.K8sMeta, opts remote.DeleteOptions) (*remote.SyncResult, error) {
 		return &remote.SyncResult{Type: remote.SyncDeleted}, nil
 	}
 	err := s.executeCommand("delete", "dev", "-c", "service2")
@@ -62,7 +62,7 @@ func TestDeleteLocal(t *testing.T) {
 	defer s.reset()
 	d := &dg{cmValue: "baz", secretValue: "baz"}
 	s.client.getFunc = d.get
-	s.client.deleteFunc = func(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error) {
+	s.client.deleteFunc = func(obj model.K8sMeta, opts remote.DeleteOptions) (*remote.SyncResult, error) {
 		return &remote.SyncResult{Type: remote.SyncDeleted}, nil
 	}
 	err := s.executeCommand("delete", "dev", "--local", "-C", "cluster-objects")

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -224,7 +224,7 @@ func (d *differ) diff(ob model.K8sMeta) error {
 
 	if ob.GetName() != "" {
 		remoteObject, err = d.client.Get(ob)
-		if err != nil && err != remote.ErrNotFound {
+		if err != nil && err != remote.ErrNotFound && err.Error() != "server type not found" { // *sigh*
 			d.stats.errors(name)
 			sio.Errorf("error fetching %s, %v\n", name, err)
 			return err

--- a/internal/commands/directives.go
+++ b/internal/commands/directives.go
@@ -1,0 +1,90 @@
+/*
+   Copyright 2019 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/splunk/qbec/internal/model"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	policyNever = "never"
+)
+
+// isSet return true if the annotation name specified as directive is equal to the supplied value.
+func isSet(ob model.K8sMeta, directive, value string) bool {
+	anns := ob.GetAnnotations()
+	if anns != nil {
+		v := anns[directive]
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+type updatePolicy struct{}
+
+func (u *updatePolicy) disableUpdate(ob model.K8sMeta) bool {
+	return isSet(ob, model.QbecNames.Directives.UpdatePolicy, policyNever)
+}
+
+func newUpdatePolicy() *updatePolicy {
+	return &updatePolicy{}
+}
+
+type deletePolicy struct {
+	nsFunc         func(kind schema.GroupVersionKind) (bool, error)
+	defaultNS      string
+	keepNamespaces map[string]bool
+}
+
+func newDeletePolicy(nsFunc func(kind schema.GroupVersionKind) (bool, error), defaultNS string) *deletePolicy {
+	return &deletePolicy{nsFunc: nsFunc, keepNamespaces: map[string]bool{
+		"default":     true, // never try to delete the default namespace
+		"kube-system": true, // ditto for system namespace
+	}}
+}
+
+func (d *deletePolicy) disableDelete(ob model.K8sMeta) bool {
+	ret := isSet(ob, model.QbecNames.Directives.DeletePolicy, policyNever)
+	if ret {
+		isNamespaced, _ := d.nsFunc(ob.GroupVersionKind())
+		if isNamespaced {
+			ns := ob.GetNamespace()
+			if ns == "" {
+				ns = d.defaultNS
+			}
+			d.keepNamespaces[ns] = true
+		}
+		return true
+	}
+	if ob.GroupVersionKind().Group == "" && ob.GetKind() == "Namespace" {
+		return d.keepNamespaces[ob.GetName()]
+	}
+	return false
+}
+
+type waitForTypePolicy struct{}
+
+func (w *waitForTypePolicy) shouldWaitForType(ob model.K8sMeta) bool {
+	return isSet(ob, model.QbecNames.Directives.LazyType, "true")
+}
+
+func newWaitForTypePolicy() *waitForTypePolicy {
+	return &waitForTypePolicy{}
+}

--- a/internal/commands/directives_test.go
+++ b/internal/commands/directives_test.go
@@ -1,0 +1,130 @@
+/*
+   Copyright 2019 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/splunk/qbec/internal/model"
+	"github.com/splunk/qbec/internal/sio"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func k8sMetaWithAnnotations(kind, namespace, name string, anns map[string]interface{}) model.K8sMeta {
+	meta := map[string]interface{}{
+		"name":        name,
+		"annotations": anns,
+	}
+	if namespace != "" {
+		meta["namespace"] = namespace
+	}
+	return model.NewK8sObject(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       kind,
+		"metadata":   meta,
+	})
+}
+
+func TestDirectivesIsSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		anns     map[string]interface{}
+		expected bool
+		warning  string
+	}{
+		{
+			"nil-annotations", nil, false, "",
+		},
+		{
+			"empty-annotations", map[string]interface{}{}, false, "",
+		},
+		{
+			"nomatch-annotations", map[string]interface{}{"x": "always"}, false, "",
+		},
+		{
+			"match-annotations", map[string]interface{}{"x": "never"}, true, "",
+		},
+		{
+			"bad-annotations", map[string]interface{}{"x": "garbage"}, false, "ignored annotation x=garbage does not have one of the allowed values: always, never",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var b bytes.Buffer
+			orig := sio.Output
+			defer func() {
+				sio.Output = orig
+			}()
+			sio.Output = &b
+			ret := isSet(k8sMetaWithAnnotations("ConfigMap", "default", "bar", test.anns), "x", "never", []string{"always"})
+			assert.EqualValues(t, test.expected, ret)
+			if test.warning != "" {
+				assert.Contains(t, b.String(), test.warning)
+			}
+		})
+	}
+}
+
+func TestDirectivesUpdatePolicy(t *testing.T) {
+	up := newUpdatePolicy()
+	a := assert.New(t)
+	ret := up.disableUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", nil))
+	a.False(ret)
+	ret = up.disableUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", map[string]interface{}{
+		"directives.qbec.io/update-policy": "never",
+	}))
+	a.True(ret)
+}
+
+func TestDirectivesWaitForTypePolicy(t *testing.T) {
+	wp := newWaitForTypePolicy()
+	a := assert.New(t)
+	ret := wp.shouldWaitForType(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", nil))
+	a.False(ret)
+	ret = wp.shouldWaitForType(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", map[string]interface{}{
+		"directives.qbec.io/lazy-type": "true",
+	}))
+	a.True(ret)
+}
+
+func TestDirectivesDeletePolicy(t *testing.T) {
+	dp := newDeletePolicy(func(gvk schema.GroupVersionKind) (bool, error) {
+		return gvk.Kind == "ConfigMap", nil
+	}, "foobar")
+	a := assert.New(t)
+	a.True(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "default", nil)))
+	a.True(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "kube-system", nil)))
+	a.False(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "foobar", nil)))
+	a.False(dp.disableDelete(k8sMetaWithAnnotations("ConfigMap", "default", "foobar", nil)))
+
+	disableAnns := map[string]interface{}{
+		"directives.qbec.io/delete-policy": "never",
+	}
+	cmNoNs := k8sMetaWithAnnotations("ConfigMap", "", "cm1", disableAnns)
+	a.True(dp.disableDelete(cmNoNs))
+	a.True(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "foobar", nil)))
+
+	cmNs := k8sMetaWithAnnotations("ConfigMap", "xxx", "cm1", disableAnns)
+	a.True(dp.disableDelete(cmNs))
+	a.True(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "xxx", nil)))
+
+	clusterNs := k8sMetaWithAnnotations("ClusterObj", "yyy", "cobj1", disableAnns)
+	a.True(dp.disableDelete(clusterNs))
+	a.False(dp.disableDelete(k8sMetaWithAnnotations("Namespace", "", "yyy", nil)))
+}

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -61,13 +61,15 @@ type basicObject struct {
 	tag       string
 	component string
 	env       string
+	anns      map[string]string
 }
 
-func (b *basicObject) Application() string     { return b.app }
-func (b *basicObject) Tag() string             { return b.tag }
-func (b *basicObject) Component() string       { return b.component }
-func (b *basicObject) Environment() string     { return b.env }
-func (b *basicObject) GetGenerateName() string { return "" }
+func (b *basicObject) Application() string               { return b.app }
+func (b *basicObject) Tag() string                       { return b.tag }
+func (b *basicObject) Component() string                 { return b.component }
+func (b *basicObject) Environment() string               { return b.env }
+func (b *basicObject) GetGenerateName() string           { return "" }
+func (b *basicObject) GetAnnotations() map[string]string { return b.anns }
 
 type coll struct {
 	data map[objectKey]model.K8sQbecMeta
@@ -111,7 +113,7 @@ type client struct {
 	syncFunc      func(obj model.K8sLocalObject, opts remote.SyncOptions) (*remote.SyncResult, error)
 	validatorFunc func(gvk schema.GroupVersionKind) (k8smeta.Validator, error)
 	listFunc      func(scope remote.ListQueryConfig) (remote.Collection, error)
-	deleteFunc    func(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error)
+	deleteFunc    func(obj model.K8sMeta, opts remote.DeleteOptions) (*remote.SyncResult, error)
 	objectKeyFunc func(obj model.K8sMeta) string
 }
 
@@ -157,9 +159,9 @@ func (c *client) ListObjects(scope remote.ListQueryConfig) (remote.Collection, e
 	return nil, errors.New("not implemented")
 }
 
-func (c *client) Delete(obj model.K8sMeta, dryRun bool) (*remote.SyncResult, error) {
+func (c *client) Delete(obj model.K8sMeta, opts remote.DeleteOptions) (*remote.SyncResult, error) {
 	if c.deleteFunc != nil {
-		return c.deleteFunc(obj, dryRun)
+		return c.deleteFunc(obj, opts)
 	}
 	return nil, errors.New("not implemented")
 }

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -245,6 +245,9 @@ func evalComponent(ctx Context, c model.Component, pe postProc) ([]model.K8sLoca
 		if err != nil {
 			return nil, err
 		}
+		if err := model.AssertMetadataValid(proc); err != nil {
+			return nil, err
+		}
 		processed = append(processed, model.NewK8sLocalObject(proc, ctx.App, ctx.Tag, c.Name, ctx.Env))
 	}
 	return processed, nil

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -287,6 +287,28 @@ func TestEvalComponentsBadObjects(t *testing.T) {
 	require.Contains(t, err.Error(), `unexpected type for object (string) at path "$[0].foo"`)
 }
 
+func TestEvalComponentsBadMetadata(t *testing.T) {
+	_, err := Components([]model.Component{
+		{
+			Name:  "bad-metadata",
+			Files: []string{"testdata/components/bad-metadata.yaml"},
+		},
+	}, Context{Env: "dev"})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), `/v1, Kind=ConfigMap, Name=subdir-config-map1: .metadata.annotations accessor error`)
+}
+
+func TestEvalComponentsBadPostProc(t *testing.T) {
+	_, err := Components([]model.Component{
+		{
+			Name:  "bad-postproc",
+			Files: []string{"testdata/components/b.yaml"},
+		},
+	}, Context{Env: "dev", PostProcessFile: "testdata/components/bad-pp.libsonnet"})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), `post-eval did not return an object`)
+}
+
 func TestEvalPostProcessor(t *testing.T) {
 	obj := map[string]interface{}{
 		"apiVersion": "v1",

--- a/internal/eval/testdata/components/bad-metadata.yaml
+++ b/internal/eval/testdata/components/bad-metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: subdir-config-map1
+  annotations:
+    do-it: true
+data:
+  foo: bar

--- a/internal/eval/testdata/components/bad-pp.libsonnet
+++ b/internal/eval/testdata/components/bad-pp.libsonnet
@@ -1,0 +1,3 @@
+function (object) (
+  [ object ]
+)

--- a/internal/model/external-names.go
+++ b/internal/model/external-names.go
@@ -19,6 +19,17 @@ package model
 // QBECMetadataPrefix is the leading path for all metadata set by qbec.
 const QBECMetadataPrefix = "qbec.io/"
 
+// QBECDirectivesNamespace is the leading path for all directives set by the user for qbec use.
+const QBECDirectivesNamespace = "directives.qbec.io/"
+
+// Directives is the list of directive names we support.
+type Directives struct {
+	ApplyOrder   string // numeric apply order for object
+	DeletePolicy string // delete policy "default" | "never"
+	UpdatePolicy string // update policy "default" | "never"
+	LazyType     string // wait for (CRD) type to appear before applying object "false" (default) | "true". Will also process diffs and apply dry-run without errors
+}
+
 // QbecNames is the set of names used by Qbec.
 var QbecNames = struct {
 	ApplicationLabel    string // the label to use for tagging an object with an application name
@@ -30,6 +41,7 @@ var QbecNames = struct {
 	TagVarName          string // the name of the external variable that has the tag name
 	DefaultNsVarName    string // the name of the external variable that has the default namespace
 	CleanModeVarName    string // name of external variable that has the indicator for clean mode
+	Directives          Directives
 }{
 	ApplicationLabel:    QBECMetadataPrefix + "application",
 	TagLabel:            QBECMetadataPrefix + "tag",
@@ -40,4 +52,10 @@ var QbecNames = struct {
 	TagVarName:          QBECMetadataPrefix + "tag",
 	DefaultNsVarName:    QBECMetadataPrefix + "defaultNs",
 	CleanModeVarName:    QBECMetadataPrefix + "cleanMode",
+	Directives: Directives{
+		ApplyOrder:   QBECDirectivesNamespace + "apply-order",
+		DeletePolicy: QBECDirectivesNamespace + "delete-policy",
+		UpdatePolicy: QBECDirectivesNamespace + "update-policy",
+		LazyType:     QBECDirectivesNamespace + "lazy-type",
+	},
 }

--- a/internal/remote/collection.go
+++ b/internal/remote/collection.go
@@ -40,13 +40,15 @@ type basicObject struct {
 	tag       string
 	component string
 	env       string
+	anns      map[string]string
 }
 
-func (b *basicObject) Application() string     { return b.app }
-func (b *basicObject) Tag() string             { return b.tag }
-func (b *basicObject) Component() string       { return b.component }
-func (b *basicObject) Environment() string     { return b.env }
-func (b *basicObject) GetGenerateName() string { return "" }
+func (b *basicObject) Application() string               { return b.app }
+func (b *basicObject) Tag() string                       { return b.tag }
+func (b *basicObject) Component() string                 { return b.component }
+func (b *basicObject) Environment() string               { return b.env }
+func (b *basicObject) GetGenerateName() string           { return "" }
+func (b *basicObject) GetAnnotations() map[string]string { return b.anns }
 
 type collectMetadata interface {
 	objectNamespace(obj model.K8sMeta) string
@@ -92,6 +94,7 @@ func (c *collection) add(object model.K8sQbecMeta) error {
 		tag:       object.Tag(),
 		component: object.Component(),
 		env:       object.Environment(),
+		anns:      object.GetAnnotations(),
 	}
 	c.objects[key] = resultObject
 	return nil

--- a/internal/remote/query.go
+++ b/internal/remote/query.go
@@ -114,6 +114,7 @@ outer:
 			app:       labels[model.QbecNames.ApplicationLabel],
 			component: anns[model.QbecNames.ComponentAnnotation],
 			env:       labels[model.QbecNames.EnvironmentLabel],
+			anns:      un.GetAnnotations(),
 		}
 		ret = append(ret, mm)
 	}


### PR DESCRIPTION
* namespace for such annotations is directives.qbec.io/
* apply-order: allows for a custom apply order (numeric)
* lazy-type: indicates that the type of an object may be lazily created by a workload that is also deployed
* update-policy: never indicates that qbec shouldn't update an object that exists
* delete-policy: never indicates that an object should not be deleted by qbec.

When an object is not deleted because of a delete policy, qbec ensures that its corresponding namespace will also not be deleted.

The default and kube-system namespaces will also never be deleted independent of annotations.

The update and delete policies are consulted from the object in etcd metadata and not the local object. The other annotations are consulted from the local object.