### PR TITLE
Add qbec to splunk/homebrew-tap 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     name: goreleaser
     steps:
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Install package dependencies
-      run: |
-        echo "::set-env name=GO_VERSION::$(go version | awk '{ print $3}' | sed 's/^go//')"
-        make get
-    - name: Release via goreleaser
-      uses: goreleaser/goreleaser-action@master
-      with:
-        args: release --rm-dist --release-notes .release-notes.md
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Install package dependencies
+        run: |
+          echo "::set-env name=GO_VERSION::$(go version | awk '{ print $3}' | sed 's/^go//')"
+          make get
+      - name: Release via goreleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          args: release --rm-dist --release-notes .release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_PERSONAL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,4 +26,4 @@ jobs:
         with:
           args: release --rm-dist --release-notes .release-notes.md
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_PERSONAL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,9 +46,7 @@ brews:
       name: Harsimran Singh Maan
       email: maan.harry@gmail.com
     homepage: "https://qbec.io/"
-    description: |
-      Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
-      It is based on jsonnet and is similar to other tools in the same space like kubecfg and ksonnet.
+    description: Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
 
     test: |
       system "#{bin}/qbec --version"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,49 +2,92 @@ before:
   hooks:
     - make release-notes
 builds:
-- id: qbec
-  binary: qbec
-  main: ./
-  ldflags:
-  - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.goVersion={{.Env.GO_VERSION}}
-  env:
-  - CGO_ENABLED=0
-  goos:
-  - linux
-  - darwin
-  - windows
-  goarch:
-  - amd64
-- id: jsonnet-qbec
-  binary: jsonnet-qbec
-  main: cmd/jsonnet-qbec/main.go
-  ldflags:
-  - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.goVersion={{.Env.GO_VERSION}}
-  env:
-  - CGO_ENABLED=0
-  goos:
-  - linux
-  - darwin
-  - windows
-  goarch:
-  - amd64
+  - id: qbec
+    binary: qbec
+    main: ./
+    ldflags:
+      - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.goVersion={{.Env.GO_VERSION}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+  - id: jsonnet-qbec
+    binary: jsonnet-qbec
+    main: cmd/jsonnet-qbec/main.go
+    ldflags:
+      - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.goVersion={{.Env.GO_VERSION}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
 archives:
   - name_template: "{{.ProjectName}}-{{.Os}}-{{.Arch}}"
     format: tar.gz
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
+brews:
+  - name: qbec
+
+    # IDs of the archives to use.
+    # Defaults to all.
+    ids:
+      - qbec
+      #- jsonnet-qbec
+
+    # Github repository to push the tap to.
+    github:
+      owner: harsimranmaan
+      name: qbec
+    url_template: "https://github.com/splunk/qbec/releases/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Allows you to set a custom download strategy. Note that you'll need
+    # to implement the strategy and add it to your tap repository.
+    # Example: http://lessthanhero.io/post/homebrew-with-private-repo-releases/
+    # Default is empty.
+    #download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
+
+    # Allows you to add a custom require_relative at the top of the formula template
+    # Default is empty
+    #custom_require: custom_download_strategy
+
+    commit_author:
+      name: Harsimran Singh Maan
+      email: maan.harry@gmail.com
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://qbec.io/"
+
+    description: |
+      Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
+      It is based on jsonnet and is similar to other tools in the same space like kubecfg and ksonnet.
+
+    test: |
+      system "#{bin}/qbec --version"
+
+    install: |
+      bin.install "qbec"
+
 checksum:
-  name_template: 'sha256-checksums.txt'
+  name_template: "sha256-checksums.txt"
 snapshot:
   name_template: "{{.Version}}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-    - 'README.md'
-    - '.gitignore'
-    - '^site:'
-    - '^examples:'
-    - Merge pull request
-    - Merge branch
+      - "README.md"
+      - ".gitignore"
+      - "^site:"
+      - "^examples:"
+      - Merge pull request
+      - Merge branch

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,39 +34,18 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+
 brews:
   - name: qbec
-
-    # IDs of the archives to use.
-    # Defaults to all.
-    ids:
-      - qbec
-      #- jsonnet-qbec
-
-    # Github repository to push the tap to.
     github:
       owner: harsimranmaan
-      name: qbec
-    url_template: "https://github.com/splunk/qbec/releases/{{ .Tag }}/{{ .ArtifactName }}"
-
-    # Allows you to set a custom download strategy. Note that you'll need
-    # to implement the strategy and add it to your tap repository.
-    # Example: http://lessthanhero.io/post/homebrew-with-private-repo-releases/
-    # Default is empty.
-    #download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
-
-    # Allows you to add a custom require_relative at the top of the formula template
-    # Default is empty
-    #custom_require: custom_download_strategy
+      name: homebrew-tap
+    url_template: https://github.com/splunk/qbec/releases/{{.Tag}}/{{.ArtifactName}}
 
     commit_author:
       name: Harsimran Singh Maan
       email: maan.harry@gmail.com
-
-    # Your app's homepage.
-    # Default is empty.
     homepage: "https://qbec.io/"
-
     description: |
       Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
       It is based on jsonnet and is similar to other tools in the same space like kubecfg and ksonnet.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,7 @@ archives:
 brews:
   - name: qbec
     github:
-      owner: harsimranmaan
+      owner: splunk
       name: homebrew-tap
     url_template: https://github.com/splunk/qbec/releases/download/{{.Tag}}/{{.ArtifactName}}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,10 +41,6 @@ brews:
       owner: splunk
       name: homebrew-tap
     url_template: https://github.com/splunk/qbec/releases/download/{{.Tag}}/{{.ArtifactName}}
-
-    commit_author:
-      name: Harsimran Singh Maan
-      email: maan.harry@gmail.com
     homepage: "https://qbec.io/"
     description: Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ brews:
     github:
       owner: harsimranmaan
       name: homebrew-tap
-    url_template: https://github.com/splunk/qbec/releases/{{.Tag}}/{{.ArtifactName}}
+    url_template: https://github.com/splunk/qbec/releases/download/{{.Tag}}/{{.ArtifactName}}
 
     commit_author:
       name: Harsimran Singh Maan

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,7 @@ brews:
     description: Qbec (pronounced like the Canadian province) is a CLI tool that allows you to create Kubernetes objects on multiple Kubernetes clusters or namespaces configured correctly for the target environment in question.
 
     test: |
-      system "#{bin}/qbec --version"
+      system "#{bin}/qbec version"
 
     install: |
       bin.install "qbec"


### PR DESCRIPTION
Update goreleaser config to publish to homebrew tap upon release of a new binary.
This change would require a new secret be added to the repository called GITHUB_ACCESS_TOKEN which should have write access to both splunk/qbec and splunk/homebrew-tap. Ideally a bot user would be preferred but a human would do no harm as long as the person stays as a maintainer for the projects.

Thanks @aaqel-s for the help with testing.

 Happy new year 🎉 