### PR TITLE
fix implementation of namespace override to affect all users of this attribute

### DIFF
--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -69,10 +69,6 @@ type stdClientProvider struct {
 
 func (s stdClientProvider) wrapOpts(opts remote.ConnectOpts) remote.ConnectOpts {
 	opts.ForceContext = s.force.K8sContext
-	if s.force.K8sNamespace != "" {
-		sio.Warnln("force default namespace to", s.force.K8sNamespace)
-		opts.Namespace = s.force.K8sNamespace
-	}
 	opts.Verbosity = s.verbosity
 	return opts
 }
@@ -274,7 +270,7 @@ func (c Config) EvalContext(env string, props map[string]interface{}) eval.Conte
 		Tag:             c.App().Tag(),
 		Env:             env,
 		EnvPropsJSON:    string(p),
-		DefaultNs:       c.app.DefaultNamespace(env),
+		DefaultNs:       c.App().DefaultNamespace(env),
 		VMConfig:        c.vmConfig,
 		Verbose:         c.Verbosity() > 1,
 		Concurrency:     c.EvalConcurrency(),

--- a/internal/model/app_test.go
+++ b/internal/model/app_test.go
@@ -150,6 +150,11 @@ func TestAppSimple(t *testing.T) {
 	a.Equal("default", app.DefaultNamespace("dev"))
 	a.Equal("", app.Tag())
 
+	app.SetOverrideNamespace("")
+	a.Equal("default", app.DefaultNamespace("dev"))
+	app.SetOverrideNamespace("foobar")
+	a.Equal("foobar", app.DefaultNamespace("dev"))
+
 	_, err = app.ServerURL("devx")
 	require.NotNil(t, err)
 	a.Equal(`invalid environment "devx"`, err.Error())

--- a/setup.go
+++ b/setup.go
@@ -158,15 +158,17 @@ func setup(root *cobra.Command) {
 		if err := setWorkDir(rootDir); err != nil {
 			return err
 		}
+		forceOpts := forceOptsFn()
 		app, err := model.NewApp("qbec.yaml", appTag)
 		if err != nil {
 			return err
 		}
+		app.SetOverrideNamespace(forceOpts.K8sNamespace)
 		vmConfig, err := vmConfigFn()
 		if err != nil {
 			return commands.NewRuntimeError(err)
 		}
-		cmdCfg, err = cp.Config(app, vmConfig, remoteConfig, forceOptsFn())
+		cmdCfg, err = cp.Config(app, vmConfig, remoteConfig, forceOpts)
 		return err
 	}
 	commands.Setup(root, func() *commands.Config {


### PR DESCRIPTION
In previous commits, overrides to the default namespace from the command line
only affected the namespace setup for the remote connection. In particular,
the namespace name exposed by qbec to the user was not updated with the forced value.

Change this such that the app object itself knows about the override and returns it
when set. This correctly affects any caller that may be using the namespace attribute.