### PR TITLE
allow for additional environments not declared in qbec.yaml to be used

### DIFF
--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -32,7 +32,7 @@ func TestConfigCreate(t *testing.T) {
 	a := assert.New(t)
 	fn := setPwd(t, "testdata")
 	defer fn()
-	app, err := model.NewApp("qbec.yaml", "t1")
+	app, err := model.NewApp("qbec.yaml", nil, "t1")
 	require.Nil(t, err)
 	rc := &remote.Config{}
 	vmc := vm.Config{}
@@ -78,7 +78,7 @@ func TestConfigCreate(t *testing.T) {
 func TestConfigStrictVarsPass(t *testing.T) {
 	fn := setPwd(t, "testdata")
 	defer fn()
-	app, err := model.NewApp("qbec.yaml", "")
+	app, err := model.NewApp("qbec.yaml", nil, "")
 	require.Nil(t, err)
 	rc := &remote.Config{}
 	vmc := vm.Config{}
@@ -98,7 +98,7 @@ func TestConfigStrictVarsFail(t *testing.T) {
 	a := assert.New(t)
 	fn := setPwd(t, "testdata")
 	defer fn()
-	app, err := model.NewApp("qbec.yaml", "")
+	app, err := model.NewApp("qbec.yaml", nil, "")
 	require.Nil(t, err)
 	rc := &remote.Config{}
 	vmc := vm.Config{}
@@ -128,7 +128,7 @@ func TestConfigConfirm(t *testing.T) {
 	a := assert.New(t)
 	fn := setPwd(t, "testdata")
 	defer fn()
-	app, err := model.NewApp("qbec.yaml", "")
+	app, err := model.NewApp("qbec.yaml", nil, "")
 	require.Nil(t, err)
 	rc := &remote.Config{}
 	vmc := vm.Config{}

--- a/internal/commands/utils_test.go
+++ b/internal/commands/utils_test.go
@@ -291,7 +291,7 @@ func newCustomScaffold(t *testing.T, dir string) *scaffold {
 		dir = "../../examples/test-app"
 	}
 	reset := setPwd(t, dir)
-	app, err := model.NewApp("qbec.yaml", "")
+	app, err := model.NewApp("qbec.yaml", nil, "")
 	require.Nil(t, err)
 	out := bytes.NewBuffer(nil)
 

--- a/internal/model/app.go
+++ b/internal/model/app.go
@@ -72,7 +72,7 @@ func makeValError(file string, errs []error) error {
 
 }
 
-func loadEnvFiles(app *QbecApp, v *validator) error {
+func loadEnvFiles(app *QbecApp, additionalFiles []string, v *validator) error {
 	if app.Spec.Environments == nil {
 		app.Spec.Environments = map[string]Environment{}
 	}
@@ -81,7 +81,11 @@ func loadEnvFiles(app *QbecApp, v *validator) error {
 		sources[k] = "inline"
 	}
 
-	for _, file := range app.Spec.EnvFiles {
+	var allFiles []string
+	allFiles = append(allFiles, app.Spec.EnvFiles...)
+	allFiles = append(allFiles, additionalFiles...)
+
+	for _, file := range allFiles {
 		b, err := ioutil.ReadFile(file)
 		if err != nil {
 			return err
@@ -107,7 +111,7 @@ func loadEnvFiles(app *QbecApp, v *validator) error {
 }
 
 // NewApp returns an app loading its details from the supplied file.
-func NewApp(file string, tag string) (*App, error) {
+func NewApp(file string, envFiles []string, tag string) (*App, error) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -127,7 +131,7 @@ func NewApp(file string, tag string) (*App, error) {
 		return nil, makeValError(file, errs)
 	}
 
-	if err := loadEnvFiles(&qApp, v); err != nil {
+	if err := loadEnvFiles(&qApp, envFiles, v); err != nil {
 		return nil, err
 	}
 

--- a/internal/model/testdata/bad-app/envs/override-dev.yaml
+++ b/internal/model/testdata/bad-app/envs/override-dev.yaml
@@ -1,0 +1,10 @@
+apiVersion: qbec.io/v1alpha1
+kind: EnvironmentMap
+spec:
+  environments:
+    dev:
+      server: https://dev-server
+      properties:
+        envType: overridden
+      includes:
+        - b


### PR DESCRIPTION
* Add a flag `--env-file` (shortcut `-E`, defaulted from `QBEC_ENV_FILE` env var) that can be used to create environments not declared in qbec.yaml
* This allows personal environments, for example, to be checked in but not pollute qbec.yaml
* Environment files loaded from the command line are loaded relative to the current working directory from which  qbec is run. This is different from relative paths in qbec.yaml that are evaluated relative to the root directory of the project
* As documented before, files introduced this way are allowed to override environment definitions for existing environments.
  The processing order is inline, followed by files declared in qbec.yaml, and external files specified on the command line.  External files have the highest priority.