### PR TITLE
Fix unknownTypes handling

### DIFF
--- a/internal/commands/remote-list.go
+++ b/internal/commands/remote-list.go
@@ -44,10 +44,9 @@ func (s *stubLister) deletions(ignore []model.K8sLocalObject, filter func(obj mo
 }
 
 type remoteLister struct {
-	client       listClient
-	ch           chan listResult
-	unknownTypes map[schema.GroupVersionKind]bool
-	cfg          remote.ListQueryConfig
+	client listClient
+	ch     chan listResult
+	cfg    remote.ListQueryConfig
 }
 
 type listResult struct {
@@ -91,9 +90,8 @@ func newRemoteLister(client listClient, allObjects []model.K8sLocalObject, defau
 	sort.Strings(nsList)
 
 	return &remoteLister{
-			client:       client,
-			ch:           make(chan listResult, 1),
-			unknownTypes: unknown,
+			client: client,
+			ch:     make(chan listResult, 1),
 		},
 		remote.ListQueryScope{
 			Namespaces:     nsList,
@@ -129,9 +127,6 @@ func (r *remoteLister) deletions(all []model.K8sLocalObject, filter func(obj mod
 
 	var removals []model.K8sQbecMeta
 	for _, c := range all {
-		if r.unknownTypes[c.GroupVersionKind()] {
-			continue
-		}
 		if !cfg.KindFilter.ShouldInclude(c.GetKind()) {
 			continue
 		}


### PR DESCRIPTION
Hi 👋  
my colleagues had the problem that wrong things were applied to the clusters. We figured out that qbec continues processing on certain errors (see log extract below):

```
...
[warn] error getting resources for type XYZ : an error on the server ("Internal Server Error") has prevented the request from succeeding
cluster metadata load took 1.816s
...
```

Digging into the code showed that the `resolver` struct contains a `err` variable at

https://github.com/splunk/qbec/blob/e0668af709b1211dfe2b3aafb53a7176340d5ffc/internal/remote/k8smeta/meta.go#L206

which is checked at

https://github.com/splunk/qbec/blob/e0668af709b1211dfe2b3aafb53a7176340d5ffc/internal/remote/k8smeta/meta.go#L290-L292

but, as far as I see, it was never assigned. Thus the error was only logged.

This PR assigns to the err variable which will hopefully solve the issue. Unfortunately, I was not yet able to reproduce the issue and I hope that we can already analyze or verify this issue while I try to reproduce it.
