### PR TITLE
warn when using cluster scoped queries involving multiple namespaces

### DIFF
--- a/internal/remote/query.go
+++ b/internal/remote/query.go
@@ -178,6 +178,7 @@ func (o *objectLister) serverObjects(coll *collection) error {
 				addQueries(o.namespacedTypes, ns)
 			}
 		default:
+			sio.Warnf("using cluster scoped queries since multiple namespaces present (%s)\n", strings.Join(o.scope.Namespaces, ", "))
 			addQueries(o.namespacedTypes, "")
 		}
 	}


### PR DESCRIPTION
Fixes #146 