### PR TITLE
Remove goreleaser deprecation warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,7 +35,7 @@ archives:
 
 brews:
   - name: qbec
-    github:
+    tap:
       owner: splunk
       name: homebrew-tap
     url_template: https://github.com/splunk/qbec/releases/download/{{.Tag}}/{{.ArtifactName}}


### PR DESCRIPTION
See https://goreleaser.com/deprecations\#brewsgithub