### PR TITLE
add --wait-all in addition to --wait to wait on all objects

### DIFF
--- a/examples/test-app/lib/objects.libsonnet
+++ b/examples/test-app/lib/objects.libsonnet
@@ -25,7 +25,15 @@
             name: name,
         },
         spec: {
+            selector: {
+                matchLabels: {
+                    app: name
+                },
+            },
             template: {
+                metadata: {
+                    labels: { app: name },
+                },
                 spec: {
                     containers: [
                     {

--- a/internal/commands/apply_test.go
+++ b/internal/commands/apply_test.go
@@ -55,9 +55,11 @@ func TestNsWrap(t *testing.T) {
 func TestApplyBasic(t *testing.T) {
 	s := newScaffold(t)
 	defer s.reset()
+	origWait := applyWaitFn
 	applyWaitFn = func(objects []model.K8sMeta, wp rollout.WatchProvider, opts rollout.WaitOptions) (finalErr error) {
 		return nil
 	}
+	defer func() { applyWaitFn = origWait }()
 	first := true
 	var captured remote.SyncOptions
 	s.client.syncFunc = func(obj model.K8sLocalObject, opts remote.SyncOptions) (*remote.SyncResult, error) {

--- a/internal/commands/integration_test.go
+++ b/internal/commands/integration_test.go
@@ -101,6 +101,16 @@ func TestIntegrationBasic(t *testing.T) {
 		a.EqualValues(1, stats["same"])
 		a.EqualValues(2, len(stats["updated"].([]interface{})))
 	})
+	t.Run("apply3", func(t *testing.T) {
+		s := newIntegrationScaffold(t, ns, dir)
+		defer s.reset()
+		err := s.executeCommand(append(changeArgs, "apply", "local", "--wait", "--wait-all")...)
+		require.NoError(t, err)
+		stats := s.outputStats()
+		a := assert.New(t)
+		a.EqualValues(3, stats["same"])
+		s.assertErrorLineMatch(regexp.MustCompile(`waiting for readiness of 1 objects`))
+	})
 }
 
 func TestIntegrationLazyCustomResources(t *testing.T) {


### PR DESCRIPTION
Currently, if --wait is specified and the apply times out, if apply is run
for a second time it will cheerfully succeed because it has already updated
the deployment and doesn't wait for it again.

Guard against this by allowing the caller to wait on all objects independent
of whether they were changed. In the current commit, the --wait-all flag
has a default of false to preserve backwards compatibility. The next minor
version will change the default of both the --wait and --wait-all flags to true
