### PR TITLE
add recreate option for update-policy directive

### DIFF
--- a/internal/commands/apply.go
+++ b/internal/commands/apply.go
@@ -114,6 +114,7 @@ func doApply(args []string, config applyCommandConfig) error {
 
 	opts := config.syncOptions
 	opts.DisableUpdateFn = newUpdatePolicy().disableUpdate
+	opts.RecreateUpdateFn = newUpdatePolicy().recreateUpdate
 
 	if !opts.DryRun && len(objects) > 0 {
 		msg := fmt.Sprintf("will synchronize %d object(s)", len(objects))

--- a/internal/commands/apply.go
+++ b/internal/commands/apply.go
@@ -295,6 +295,7 @@ func newApplyCommand(cp configProvider) *cobra.Command {
 		if err != nil {
 			return newUsageError(fmt.Sprintf("invalid wait timeout: %s, %v", waitTime, err))
 		}
+		config.syncOptions.WaitOptions.Timeout = config.waitTimeout
 		if config.syncOptions.DryRun {
 			config.wait = false
 			config.waitAll = false

--- a/internal/commands/directives.go
+++ b/internal/commands/directives.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	policyNever   = "never"
-	policyDefault = "default"
+	policyNever    = "never"
+	policyRecreate = "recreate"
+	policyDefault  = "default"
 )
 
 // isSet return true if the annotation name specified as directive is equal to the supplied value.
@@ -62,6 +63,10 @@ type updatePolicy struct{}
 
 func (u *updatePolicy) disableUpdate(ob model.K8sMeta) bool {
 	return isSet(ob, model.QbecNames.Directives.UpdatePolicy, policyNever, []string{policyDefault})
+}
+
+func (u *updatePolicy) recreateUpdate(ob model.K8sMeta) bool {
+	return isSet(ob, model.QbecNames.Directives.UpdatePolicy, policyRecreate, []string{policyDefault})
 }
 
 func newUpdatePolicy() *updatePolicy {

--- a/internal/commands/directives_test.go
+++ b/internal/commands/directives_test.go
@@ -81,13 +81,24 @@ func TestDirectivesIsSet(t *testing.T) {
 	}
 }
 
-func TestDirectivesUpdatePolicy(t *testing.T) {
+func TestDirectivesUpdatePolicyNever(t *testing.T) {
 	up := newUpdatePolicy()
 	a := assert.New(t)
 	ret := up.disableUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", nil))
 	a.False(ret)
 	ret = up.disableUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", map[string]interface{}{
 		"directives.qbec.io/update-policy": "never",
+	}))
+	a.True(ret)
+}
+
+func TestDirectivesUpdatePolicyRecreate(t *testing.T) {
+	up := newUpdatePolicy()
+	a := assert.New(t)
+	ret := up.recreateUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", nil))
+	a.False(ret)
+	ret = up.recreateUpdate(k8sMetaWithAnnotations("ConfigMap", "foo", "bar", map[string]interface{}{
+		"directives.qbec.io/update-policy": "recreate",
 	}))
 	a.True(ret)
 }

--- a/internal/remote/client.go
+++ b/internal/remote/client.go
@@ -662,8 +662,13 @@ func (c *Client) doRecreate(obj model.K8sLocalObject, opts SyncOptions) (*update
 		return nil, err
 	}
 
+	waitTime := int64(opts.WaitOptions.Timeout.Seconds())
+	if waitTime == 0 {
+		waitTime = int64(2 * time.Minute)
+	}
 	watcher, err := ri.Watch(metav1.ListOptions{
-		FieldSelector: "metadata.name=" + obj.GetName(),
+		TimeoutSeconds: &waitTime,
+		FieldSelector:  "metadata.name=" + obj.GetName(),
 	})
 	if err != nil {
 		return nil, err

--- a/site/content/reference/directives.md
+++ b/site/content/reference/directives.md
@@ -26,10 +26,11 @@ object to remove this annotation will not work.
 #### `directives.qbec.io/update-policy` 
 
 * Annotation source: in-cluster object.
-* Allowed values: `"default"`, `"never"`
+* Allowed values: `"default"`, `"never"`, `"recreate"`
 * Default value: `"default"` 
 
 when set to `"never"`, indicates that the specific object should never be updated.
+when set to `"recreate"`, indicates that the specific object should be recreated instad of updating.
 If you want qbec to update this object, you need to remove the annotation from the in-cluster object. Changing the source
 object to remove this annotation will not work.
 


### PR DESCRIPTION
This PR adds new option:
```
directives.qbec.io/update-policy: recreate
```
Which allow to recreate resources when they change.
This might be really useful for updating jobs and some other immutable objects eg. storage class.


see https://github.com/kubernetes/kubernetes/issues/89657 for more details

solves:  https://github.com/splunk/qbec/issues/64
partially solves: https://github.com/splunk/qbec/issues/149 

Now `post-install` and `post-upgrade` helm hooks can be achieved by rewriting them with `directives.qbec.io/update-policy: recreate` annotation)

Another trick can be used if you really need to run job every apply, this can be achieved by adding another annotation with random data, eg.:
```jsonnet
  annotations: {
    'directives.qbec.io/update-policy': 'recreate',
    'apply-uuid': importstr "/proc/sys/kernel/random/uuid"
  }
```