### PR TITLE
refactor component evaluation and local object creation

### DIFF
--- a/internal/commands/common_test.go
+++ b/internal/commands/common_test.go
@@ -52,7 +52,7 @@ func (i input) makeObject() model.K8sLocalObject {
 			"foo": "bar",
 		},
 	}
-	return model.NewK8sLocalObject(data, "app1", "t1", i.component, i.env, false)
+	return model.NewK8sLocalObject(data, model.LocalAttrs{App: "app1", Tag: "t1", Component: i.component, Env: i.env})
 }
 
 func (i input) String() string {

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -293,19 +293,23 @@ func (c config) EvalContext(env string, props map[string]interface{}) eval.Conte
 		model.QbecNames.EnvPropsVarName: string(p),
 	})
 	return eval.Context{
-		VMConfig: func(tlaVars []string) vm.Config { return c.vmConfig(baseConfig, tlaVars) },
-		ObjectProducer: func(component string, data map[string]interface{}) model.K8sLocalObject {
-			return model.NewK8sLocalObject(data, model.LocalAttrs{
-				App:               c.app.Name(),
-				Tag:               c.app.Tag(),
-				Component:         component,
-				Env:               env,
-				SetComponentLabel: c.app.AddComponentLabel(),
-			})
-		},
+		VMConfig:        func(tlaVars []string) vm.Config { return c.vmConfig(baseConfig, tlaVars) },
 		Verbose:         c.Verbosity() > 1,
 		Concurrency:     c.EvalConcurrency(),
 		PostProcessFile: c.App().PostProcessor(),
+	}
+}
+
+func (c config) ObjectProducer(env string) eval.LocalObjectProducer {
+	return func(component string, data map[string]interface{}) model.K8sLocalObject {
+		app := c.app
+		return model.NewK8sLocalObject(data, model.LocalAttrs{
+			App:               app.Name(),
+			Tag:               app.Tag(),
+			Component:         component,
+			Env:               env,
+			SetComponentLabel: app.AddComponentLabel(),
+		})
 	}
 }
 

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -195,7 +195,7 @@ type config struct {
 // init checks variables and sets up defaults. In strict mode, it requires all variables
 // to be specified and does not allow undeclared variables to be passed in.
 // It also sets the base VM config to include the library paths from the app definition
-// and exclude all TLA variables. Require TLA variables are set per component later.
+// and exclude all TLA variables. Required TLA variables are set per component later.
 func (c *config) init(strict bool) error {
 	var msgs []string
 	c.tlaVars = c.vmc.TopLevelVars()
@@ -280,24 +280,38 @@ func (c config) EvalContext(env string, props map[string]interface{}) eval.Conte
 	if err != nil {
 		sio.Warnln("unable to serialize env properties to JSON:", err)
 	}
+	cm := "off"
+	if c.cleanEvalMode {
+		cm = "on"
+	}
+	baseConfig := c.vmc.WithVars(map[string]string{
+		model.QbecNames.EnvVarName:       env,
+		model.QbecNames.TagVarName:       c.app.Tag(),
+		model.QbecNames.DefaultNsVarName: c.app.DefaultNamespace(env),
+		model.QbecNames.CleanModeVarName: cm,
+	}).WithCodeVars(map[string]string{
+		model.QbecNames.EnvPropsVarName: string(p),
+	})
 	return eval.Context{
-		App:               c.App().Name(),
-		Tag:               c.App().Tag(),
-		Env:               env,
-		EnvPropsJSON:      string(p),
-		DefaultNs:         c.App().DefaultNamespace(env),
-		VMConfig:          c.vmConfig,
-		Verbose:           c.Verbosity() > 1,
-		AddComponentLabel: c.App().AddComponentLabel(),
-		Concurrency:       c.EvalConcurrency(),
-		PostProcessFile:   c.App().PostProcessor(),
-		CleanMode:         c.cleanEvalMode,
+		VMConfig: func(tlaVars []string) vm.Config { return c.vmConfig(baseConfig, tlaVars) },
+		ObjectProducer: func(component string, data map[string]interface{}) model.K8sLocalObject {
+			return model.NewK8sLocalObject(data, model.LocalAttrs{
+				App:               c.app.Name(),
+				Tag:               c.app.Tag(),
+				Component:         component,
+				Env:               env,
+				SetComponentLabel: c.app.AddComponentLabel(),
+			})
+		},
+		Verbose:         c.Verbosity() > 1,
+		Concurrency:     c.EvalConcurrency(),
+		PostProcessFile: c.App().PostProcessor(),
 	}
 }
 
 // vmConfig returns the VM configuration that only has the supplied top-level arguments.
-func (c config) vmConfig(tlaVars []string) vm.Config {
-	cfg := c.vmc.WithoutTopLevel()
+func (c config) vmConfig(baseConfig vm.Config, tlaVars []string) vm.Config {
+	cfg := baseConfig.WithoutTopLevel()
 
 	// common case to avoid useless object creation. If no required vars
 	// needed or none present, just return the config with empty TLAs

--- a/internal/commands/config_test.go
+++ b/internal/commands/config_test.go
@@ -62,18 +62,22 @@ func TestConfigCreate(t *testing.T) {
 	a.Nil(cfg.Confirm("we will destroy you"))
 
 	ctx := cfg.EvalContext("dev", map[string]interface{}{"foo": "bar"})
-	a.Equal("app1", ctx.App)
-	a.Equal("dev", ctx.Env)
-	a.Equal("t1", ctx.Tag)
-	a.Equal("kube-system-t1", ctx.DefaultNs)
 	a.Equal(cfg.EvalConcurrency(), ctx.Concurrency)
-	a.Equal(false, ctx.AddComponentLabel)
 
 	testVMC := ctx.VMConfig([]string{"tlaFoo", "tlaBar"})
 	a.EqualValues(map[string]string{"tlaFoo": "xxx"}, testVMC.TopLevelVars())
 	a.EqualValues(map[string]string{"tlaBar": "true"}, testVMC.TopLevelCodeVars())
-	a.EqualValues(map[string]string{"extFoo": "xxx"}, testVMC.Vars())
-	a.EqualValues(map[string]string{"extBar": `{"bar":"quux"}`}, testVMC.CodeVars())
+	a.EqualValues(map[string]string{
+		"extFoo":            "xxx",
+		"qbec.io/cleanMode": "off",
+		"qbec.io/defaultNs": "kube-system-t1",
+		"qbec.io/env":       "dev",
+		"qbec.io/tag":       "t1",
+	}, testVMC.Vars())
+	a.EqualValues(map[string]string{
+		"extBar":                `{"bar":"quux"}`,
+		"qbec.io/envProperties": `{"foo":"bar"}`,
+	}, testVMC.CodeVars())
 }
 
 func TestConfigStrictVarsPass(t *testing.T) {
@@ -207,7 +211,12 @@ data:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ret := ordering(model.NewK8sLocalObject(test.data, "app", "tag", "component", "env", false))
+			ret := ordering(model.NewK8sLocalObject(test.data, model.LocalAttrs{
+				App:       "app",
+				Tag:       "tag",
+				Component: "component",
+				Env:       "env",
+			}))
 			assert.Equal(t, test.expected, ret)
 		})
 	}

--- a/internal/commands/filter.go
+++ b/internal/commands/filter.go
@@ -116,7 +116,7 @@ func filteredObjects(cfg *config, env string, kf keyFunc, fp filterParams) ([]mo
 	if err != nil {
 		return nil, err
 	}
-	output, err := eval.Components(components, cfg.EvalContext(env, props))
+	output, err := eval.Components(components, cfg.EvalContext(env, props), cfg.ObjectProducer(env))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/model/app.go
+++ b/internal/model/app.go
@@ -268,6 +268,8 @@ func (a *App) LibPaths() []string {
 	return a.inner.Spec.LibPaths
 }
 
+// AddComponentLabel returns if the qbec component name should be added as an object label in addition to the
+// standard annotation.
 func (a *App) AddComponentLabel() bool {
 	return a.inner.Spec.AddComponentLabel
 }

--- a/internal/model/k8s.go
+++ b/internal/model/k8s.go
@@ -133,22 +133,31 @@ func NewK8sObject(data map[string]interface{}) K8sObject {
 	return &ko{Unstructured: toUnstructured(data)}
 }
 
+// LocalAttrs are the attributes used to create local k8s objects.
+type LocalAttrs struct {
+	App               string
+	Tag               string
+	Component         string
+	Env               string
+	SetComponentLabel bool
+}
+
 // NewK8sLocalObject wraps a K8sLocalObject implementation around the unstructured object data specified as a bag
 // of attributes for the supplied application, component and environment.
-func NewK8sLocalObject(data map[string]interface{}, app, tag, component, env string, setComponentAsLabel bool) K8sLocalObject {
+func NewK8sLocalObject(data map[string]interface{}, attrs LocalAttrs) K8sLocalObject {
 	base := toUnstructured(data)
-	ret := &ko{Unstructured: base, app: app, tag: tag, comp: component, env: env}
+	ret := &ko{Unstructured: base, app: attrs.App, tag: attrs.Tag, comp: attrs.Component, env: attrs.Env}
 	labels := base.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	labels[QbecNames.ApplicationLabel] = app
-	if tag != "" {
-		labels[QbecNames.TagLabel] = tag
+	labels[QbecNames.ApplicationLabel] = attrs.App
+	if attrs.Tag != "" {
+		labels[QbecNames.TagLabel] = attrs.Tag
 	}
-	labels[QbecNames.EnvironmentLabel] = env
-	if setComponentAsLabel {
-		labels[QbecNames.ComponentLabel] = component
+	labels[QbecNames.EnvironmentLabel] = attrs.Env
+	if attrs.SetComponentLabel {
+		labels[QbecNames.ComponentLabel] = attrs.Component
 	}
 	base.SetLabels(labels)
 
@@ -156,7 +165,7 @@ func NewK8sLocalObject(data map[string]interface{}, app, tag, component, env str
 	if anns == nil {
 		anns = map[string]string{}
 	}
-	anns[QbecNames.ComponentAnnotation] = component
+	anns[QbecNames.ComponentAnnotation] = attrs.Component
 	base.SetAnnotations(anns)
 	return ret
 }

--- a/internal/model/k8s_test.go
+++ b/internal/model/k8s_test.go
@@ -64,7 +64,7 @@ func TestK8sObject(t *testing.T) {
 }
 
 func TestK8sLocalObject(t *testing.T) {
-	obj := NewK8sLocalObject(toData(cm), "app1", "", "c1", "e1", false)
+	obj := NewK8sLocalObject(toData(cm), LocalAttrs{App: "app1", Tag: "", Component: "c1", Env: "e1"})
 	a := assert.New(t)
 	a.Equal("app1", obj.Application())
 	a.Equal("c1", obj.Component())
@@ -80,7 +80,7 @@ func TestK8sLocalObject(t *testing.T) {
 }
 
 func TestK8sLocalObjectWithTag(t *testing.T) {
-	obj := NewK8sLocalObject(toData(cm), "app1", "t1", "c1", "e1", false)
+	obj := NewK8sLocalObject(toData(cm), LocalAttrs{App: "app1", Tag: "t1", Component: "c1", Env: "e1"})
 	a := assert.New(t)
 	a.Equal("app1", obj.Application())
 	a.Equal("c1", obj.Component())
@@ -95,7 +95,7 @@ func TestK8sLocalObjectWithTag(t *testing.T) {
 }
 
 func TestK8sLocalObjectWithComponentLabel(t *testing.T) {
-	obj := NewK8sLocalObject(toData(cm), "app1", "t1", "c1", "e1", true)
+	obj := NewK8sLocalObject(toData(cm), LocalAttrs{App: "app1", Tag: "t1", Component: "c1", Env: "e1", SetComponentLabel: true})
 	a := assert.New(t)
 	a.Equal("app1", obj.Application())
 	a.Equal("c1", obj.Component())

--- a/internal/objsort/sort_test.go
+++ b/internal/objsort/sort_test.go
@@ -42,7 +42,7 @@ func object(d data) model.K8sLocalObject {
 			"namespace": d.namespace,
 			"name":      d.name,
 		},
-	}, "app1", "", d.component, "dev", false)
+	}, model.LocalAttrs{App: "app1", Tag: "", Component: d.component, Env: "dev"})
 }
 
 func TestBasicSort(t *testing.T) {

--- a/internal/remote/pristine.go
+++ b/internal/remote/pristine.go
@@ -115,7 +115,12 @@ func (k qbecPristine) createFromPristine(pristine model.K8sLocalObject) (model.K
 	}
 	annotations[model.QbecNames.PristineAnnotation] = zipped
 	annotated.SetAnnotations(annotations)
-	return model.NewK8sLocalObject(annotated.Object, pristine.Application(), pristine.Tag(), pristine.Component(), pristine.Environment(), false), nil
+	return model.NewK8sLocalObject(annotated.Object, model.LocalAttrs{
+		App:       pristine.Application(),
+		Tag:       pristine.Tag(),
+		Component: pristine.Component(),
+		Env:       pristine.Environment(),
+	}), nil
 }
 
 const kubectlLastConfig = "kubectl.kubernetes.io/last-applied-configuration"

--- a/internal/remote/pristine_test.go
+++ b/internal/remote/pristine_test.go
@@ -192,7 +192,7 @@ func TestPristineReaderNoFallback(t *testing.T) {
 func TestCreateFromPristine(t *testing.T) {
 	un := loadFile(t, "input.yaml")
 	p := qbecPristine{}
-	obj := model.NewK8sLocalObject(un.Object, "app", "", "comp1", "dev", false)
+	obj := model.NewK8sLocalObject(un.Object, model.LocalAttrs{App: "app", Tag: "", Component: "comp1", Env: "dev"})
 	ret, err := p.createFromPristine(obj)
 	require.Nil(t, err)
 	a := assert.New(t)

--- a/internal/types/secrets.go
+++ b/internal/types/secrets.go
@@ -96,5 +96,10 @@ func HideSensitiveLocalInfo(in model.K8sLocalObject) (model.K8sLocalObject, bool
 	if !changed {
 		return in, false
 	}
-	return model.NewK8sLocalObject(obj.Object, in.Application(), in.Tag(), in.Component(), in.Environment(), false), true
+	return model.NewK8sLocalObject(obj.Object, model.LocalAttrs{
+		App:       in.Application(),
+		Tag:       in.Tag(),
+		Component: in.Component(),
+		Env:       in.Environment(),
+	}), true
 }

--- a/internal/types/secrets_test.go
+++ b/internal/types/secrets_test.go
@@ -60,8 +60,8 @@ func toData(s string) map[string]interface{} {
 }
 
 func TestSecrets(t *testing.T) {
-	cmObj := model.NewK8sLocalObject(toData(cm), "app1", "", "c1", "e1", false)
-	secretObj := model.NewK8sLocalObject(toData(secret), "", "app1", "c1", "e1", false)
+	cmObj := model.NewK8sLocalObject(toData(cm), model.LocalAttrs{App: "app1", Tag: "", Component: "c1", Env: "e1"})
+	secretObj := model.NewK8sLocalObject(toData(secret), model.LocalAttrs{App: "app1", Component: "c1", Env: "e1"})
 	a := assert.New(t)
 	a.False(HasSensitiveInfo(cmObj.ToUnstructured()))
 	a.True(HasSensitiveInfo(secretObj.ToUnstructured()))


### PR DESCRIPTION
No functionality changes. 

* `NewK8sLocalObject` no longer accepts half a dozen arguments but a typed struct instead
* `eval` package no longer knows about qbec specific annotations and local object creation
* this functionality moved to the config struct in the commands package