### PR TITLE
allow componentsDir to be a glob

### DIFF
--- a/internal/model/testdata/multi-dir-app/components/README.md
+++ b/internal/model/testdata/multi-dir-app/components/README.md
@@ -1,0 +1,4 @@
+### multi dirs
+
+A multi dir app is allowed to have files that are ignored.
+

--- a/internal/model/testdata/multi-dir-app/components/dir1/a.jsonnet
+++ b/internal/model/testdata/multi-dir-app/components/dir1/a.jsonnet
@@ -1,0 +1,10 @@
+{
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+        name: 'cm-a',
+    },
+    data: {
+      foo: 'bar'
+    }
+}

--- a/internal/model/testdata/multi-dir-app/components/dir2/b/index.jsonnet
+++ b/internal/model/testdata/multi-dir-app/components/dir2/b/index.jsonnet
@@ -1,0 +1,11 @@
+{
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+        name: 'cm-b',
+    },
+    data: {
+      bar: 'baz'
+    }
+}
+

--- a/internal/model/testdata/multi-dir-app/qbec.yaml
+++ b/internal/model/testdata/multi-dir-app/qbec.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: qbec.io/v1alpha1
+kind: App
+metadata:
+  name: multi-dir-app
+spec:
+  componentsDir: components/*
+  environments:
+    dev:
+      server: https://dev-server

--- a/internal/model/testdata/no-dirs-app/qbec.yaml
+++ b/internal/model/testdata/no-dirs-app/qbec.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: qbec.io/v1alpha1
+kind: App
+metadata:
+  name: no-dirs-app
+spec:
+  componentsDir: components/dir*
+  environments:
+    dev:
+      server: https://dev-server


### PR DESCRIPTION
This adds support for multiple component directories expressed as a glob,
but does not introduce any namespace semantics. Components still have to
be unqiue across all directories.