### PR TITLE
allow for ability to evaluate a single file given paths and vars

### DIFF
--- a/examples/test-app/misc/qbec.jsonnet
+++ b/examples/test-app/misc/qbec.jsonnet
@@ -1,0 +1,4 @@
+{
+    foo: std.extVar('qbec.io/env'),
+    bar: std.extVar('qbec.io/envProperties').envType,
+}

--- a/examples/test-app/misc/simple.jsonnet
+++ b/examples/test-app/misc/simple.jsonnet
@@ -1,0 +1,4 @@
+{
+    foo: 'str',
+    bar: true,
+}

--- a/examples/test-app/misc/tla.jsonnet
+++ b/examples/test-app/misc/tla.jsonnet
@@ -1,0 +1,4 @@
+function (foo, bar) {
+    foo: foo,
+    bar: bar,
+}

--- a/examples/test-app/misc/vars.jsonnet
+++ b/examples/test-app/misc/vars.jsonnet
@@ -1,0 +1,5 @@
+{
+    foo: std.extVar('foo'),
+    bar: std.extVar('bar'),
+}
+

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -103,6 +103,7 @@ func setupCommands(root *cobra.Command, cp configProvider) {
 	root.AddCommand(newApplyCommand(cp))
 	root.AddCommand(newValidateCommand(cp))
 	root.AddCommand(newShowCommand(cp))
+	root.AddCommand(newEvalCommand(cp))
 	root.AddCommand(newDiffCommand(cp))
 	root.AddCommand(newDeleteCommand(cp))
 	root.AddCommand(newComponentCommand(cp))

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -292,9 +292,11 @@ func (c config) EvalContext(env string, props map[string]interface{}) eval.Conte
 		vm.NewCodeVar(model.QbecNames.EnvPropsVarName, string(p)),
 	)
 	return eval.Context{
-		Vars:             baseVars,
-		LibPaths:         c.ext.LibPaths,
-		Verbose:          c.Verbosity() > 1,
+		BaseContext: eval.BaseContext{
+			Vars:     baseVars,
+			LibPaths: c.ext.LibPaths,
+			Verbose:  c.Verbosity() > 1,
+		},
 		Concurrency:      c.EvalConcurrency(),
 		PreProcessFiles:  c.App().PreProcessors(),
 		PostProcessFiles: c.App().PostProcessors(),

--- a/internal/commands/eval.go
+++ b/internal/commands/eval.go
@@ -1,0 +1,91 @@
+/*
+   Copyright 2021 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"github.com/splunk/qbec/internal/eval"
+	"github.com/splunk/qbec/internal/vm"
+)
+
+type evalCommandConfig struct {
+	*config
+	format string
+	env    string
+}
+
+func doEval(args []string, config evalCommandConfig) error {
+	if len(args) != 1 {
+		return newUsageError("exactly one file required")
+	}
+	var output string
+	var err error
+	if config.env == "" {
+		output, err = eval.File(args[0], eval.BaseContext{
+			LibPaths: config.ext.LibPaths,
+			Vars:     vm.VariablesFromConfig(config.ext),
+			Verbose:  config.verbose > 1,
+		})
+	} else {
+		props, err := config.App().Properties(config.env)
+		if err != nil {
+			return err
+		}
+		ctx := config.EvalContext(config.env, props)
+		output, err = eval.File(args[0], ctx.BaseContext)
+	}
+	if err != nil {
+		return err
+	}
+	var data interface{}
+	err = json.Unmarshal([]byte(output), &data)
+	if err != nil {
+		return err
+	}
+	var b []byte
+	switch config.format {
+	case "yaml":
+		b, err = yaml.Marshal(data)
+	default:
+		b, err = json.MarshalIndent(data, "", "  ")
+	}
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(config.Stdout(), "%s\n", b)
+	return nil
+}
+
+func newEvalCommand(cp configProvider) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "eval [--env <env>] path/to/file.jsonnet",
+		Short:   "evaluate the supplied file optionally under a qbec environment",
+		Example: evalExamples(),
+	}
+	cfg := evalCommandConfig{}
+	cmd.Flags().StringVarP(&cfg.format, "format", "o", "json", "Output format. Supported values are: json, yaml")
+	cmd.Flags().StringVar(&cfg.env, "env", "", "qbec environment context, optional")
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		cfg.config = cp()
+		return wrapError(doEval(args, cfg))
+	}
+	return cmd
+}

--- a/internal/commands/eval_test.go
+++ b/internal/commands/eval_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright 2021 Splunk Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalBasic(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/simple.jsonnet")
+	require.NoError(t, err)
+	var data map[string]interface{}
+	err = s.jsonOutput(&data)
+	require.NoError(t, err)
+
+	a := assert.New(t)
+	a.Equal("str", data["foo"])
+	a.Equal(true, data["bar"])
+}
+
+func TestEvalVars(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/vars.jsonnet", "--vm:ext-str", "foo=str", "--vm:ext-code", "bar=true")
+	require.NoError(t, err)
+	var data map[string]interface{}
+	err = s.jsonOutput(&data)
+	require.NoError(t, err)
+
+	a := assert.New(t)
+	a.Equal("str", data["foo"])
+	a.Equal(true, data["bar"])
+}
+
+func TestEvalTLAs(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/tla.jsonnet", "--vm:tla-str", "foo=str", "--vm:tla-code", "bar=true")
+	require.NoError(t, err)
+	var data map[string]interface{}
+	err = s.jsonOutput(&data)
+	require.NoError(t, err)
+
+	a := assert.New(t)
+	a.Equal("str", data["foo"])
+	a.Equal(true, data["bar"])
+}
+
+func TestEvalBasicYAML(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/simple.jsonnet", "--format=yaml")
+	require.NoError(t, err)
+	d, err := s.yamlOutput()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(d))
+	data, ok := d[0].(map[string]interface{})
+	require.True(t, ok)
+	a := assert.New(t)
+	a.Equal("str", data["foo"])
+	a.Equal(true, data["bar"])
+}
+
+func TestEvalInQBECContext(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/qbec.jsonnet", "--env=dev")
+	require.NoError(t, err)
+	var data map[string]interface{}
+	err = s.jsonOutput(&data)
+	a := assert.New(t)
+	a.Equal("dev", data["foo"])
+	a.Equal("development", data["bar"])
+}
+
+func TestEvalBarArgs(t *testing.T) {
+	s := newScaffold(t)
+	defer s.reset()
+	err := s.executeCommand("eval", "misc/qbec.jsonnet", "misc/simple.jsonnet")
+	require.Error(t, err)
+	assert.Equal(t, "exactly one file required", err.Error())
+}

--- a/internal/commands/eval_test.go
+++ b/internal/commands/eval_test.go
@@ -92,7 +92,7 @@ func TestEvalInQBECContext(t *testing.T) {
 	a.Equal("development", data["bar"])
 }
 
-func TestEvalBarArgs(t *testing.T) {
+func TestEvalBadArgs(t *testing.T) {
 	s := newScaffold(t)
 	defer s.reset()
 	err := s.executeCommand("eval", "misc/qbec.jsonnet", "misc/simple.jsonnet")

--- a/internal/commands/examples.go
+++ b/internal/commands/examples.go
@@ -67,6 +67,13 @@ func showExamples() string {
 	)
 }
 
+func evalExamples() string {
+	return exampleHelp(
+		newExample("eval some/file.jsonnet --vm:ext-str foo=bar", "evaluate the supplied file using simple jsonnet semantics, does not require qbec.yaml"),
+		newExample("eval some/file.jsonnet --env dev", "evaluate the supplied file using qbec semantics, automatically setting all external variables like qbec would set them for the environment"),
+	)
+}
+
 func fmtExamples() string {
 	return exampleHelp(
 		newExample("alpha fmt -w", "format all jsonnet and libsonnet files in-place"),


### PR DESCRIPTION
```
$ qbec eval --help
evaluate the supplied file optionally under a qbec environment

Usage:
  qbec eval [--env <env>] path/to/file.jsonnet [flags]

Examples:

# evaluate the supplied file using simple jsonnet semantics, does not require qbec.yaml
qbec eval some/file.jsonnet --vm:ext-str foo=bar

# evaluate the supplied file using qbec semantics, automatically setting all external variables like qbec would set them for the environment
qbec eval some/file.jsonnet --env dev

Flags:
      --env string      qbec environment context, optional
  -o, --format string   Output format. Supported values are: json, yaml (default "json")
  -h, --help            help for eval

Use "qbec options" for a list of global options available to all commands.
```