### PR TITLE
fmt does not require to be run inside qbec root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	github.com/tidwall/pretty v1.0.0
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.17.13

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,8 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -51,8 +51,9 @@ func setupCommands(root *cobra.Command, cp ctxProvider) {
 	root.AddCommand(newEnvCommand(cp))
 	root.AddCommand(newInitCommand(cp))
 	root.AddCommand(newCompletionCommand(root))
+	root.AddCommand(newFmtCommand(cp, false))
 	alplhaCmd := newAlphaCommand()
-	alplhaCmd.AddCommand(newFmtCommand(cp))
+	alplhaCmd.AddCommand(newFmtCommand(cp, true))
 	root.AddCommand(alplhaCmd)
 }
 

--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -51,9 +51,9 @@ func setupCommands(root *cobra.Command, cp ctxProvider) {
 	root.AddCommand(newEnvCommand(cp))
 	root.AddCommand(newInitCommand(cp))
 	root.AddCommand(newCompletionCommand(root))
-	root.AddCommand(newFmtCommand(cp, false))
+	root.AddCommand(newFmtCommand(cp))
 	alplhaCmd := newAlphaCommand()
-	alplhaCmd.AddCommand(newFmtCommand(cp, true))
+	alplhaCmd.AddCommand(newFmtCommand(cp))
 	root.AddCommand(alplhaCmd)
 }
 

--- a/internal/commands/examples.go
+++ b/internal/commands/examples.go
@@ -76,12 +76,12 @@ func evalExamples() string {
 
 func fmtExamples() string {
 	return exampleHelp(
-		newExample("alpha fmt -w", "format all jsonnet and libsonnet files in-place"),
-		newExample("alpha fmt -e", "check if all jsonnet and libsonnet files are formatted well. Non zero exit code in case a unformatted file is found"),
-		newExample("alpha fmt --type=json", "format all json files to stdout"),
-		newExample("alpha fmt somefolder file1.jsonnet file2.libsonnet", "format all jsonnet and libsonnet= files in the somefolder, file1.jsonnet and file2.libsonnet files to stdout"),
-		newExample("alpha fmt -t=yaml", "format all yaml files to stdout"),
-		newExample("alpha fmt --type=json,yaml somefolder file1.yaml file2.yml file3.json", "format all json and yaml files in the somefolder, file1.yaml, file2.yml and file3.json files to stdout"),
+		newExample("fmt -w", "format all jsonnet and libsonnet files in-place"),
+		newExample("fmt -e", "check if all jsonnet and libsonnet files are formatted well. Non zero exit code in case a unformatted file is found"),
+		newExample("fmt --type=json", "format all json files to stdout"),
+		newExample("fmt somefolder file1.jsonnet file2.libsonnet", "format all jsonnet and libsonnet= files in the somefolder, file1.jsonnet and file2.libsonnet files to stdout"),
+		newExample("fmt -t=yaml", "format all yaml files to stdout"),
+		newExample("fmt --type=json,yaml somefolder file1.yaml file2.yml file3.json", "format all json and yaml files in the somefolder, file1.yaml, file2.yml and file3.json files to stdout"),
 	)
 }
 

--- a/internal/commands/fmt.go
+++ b/internal/commands/fmt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-jsonnet/formatter"
 	"github.com/spf13/cobra"
 	"github.com/splunk/qbec/internal/cmd"
+	"github.com/splunk/qbec/internal/sio"
 	"github.com/tidwall/pretty"
 	"gopkg.in/yaml.v3"
 )
@@ -75,11 +76,15 @@ var (
 	supportedTypes = []string{"json", "jsonnet", "yaml"}
 )
 
-func newFmtCommand(cp ctxProvider) *cobra.Command {
+func newFmtCommand(cp ctxProvider, deprecated bool) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "fmt",
 		Short:   "format files",
 		Example: fmtExamples(),
+	}
+	deprecationNotice := "qbec alpha fmt is deprecated. Use qbec fmt instead. qbec alpha fmt would be removed in the next release"
+	if deprecated {
+		sio.Warnln(deprecationNotice)
 	}
 
 	config := fmtCommandConfig{}

--- a/internal/commands/fmt.go
+++ b/internal/commands/fmt.go
@@ -76,22 +76,22 @@ var (
 	supportedTypes = []string{"json", "jsonnet", "yaml"}
 )
 
-func newFmtCommand(cp ctxProvider, deprecated bool) *cobra.Command {
+func newFmtCommand(cp ctxProvider) *cobra.Command {
 	c := &cobra.Command{
 		Use:     "fmt",
 		Short:   "format files",
 		Example: fmtExamples(),
 	}
 	deprecationNotice := "qbec alpha fmt is deprecated. Use qbec fmt instead. qbec alpha fmt would be removed in the next release"
-	if deprecated {
-		sio.Warnln(deprecationNotice)
-	}
 
 	config := fmtCommandConfig{}
 	c.Flags().BoolVarP(&config.check, "check-errors", "e", false, "check for unformatted files")
 	c.Flags().BoolVarP(&config.write, "write", "w", false, "write result to (source) file instead of stdout")
 	c.Flags().StringSliceVarP(&config.specifiedTypes, "type", "t", []string{"jsonnet"}, "file types that should be formatted")
 	c.RunE = func(c *cobra.Command, args []string) error {
+		if c.Parent().Name() == "alpha" {
+			sio.Warnln(deprecationNotice)
+		}
 		config.AppContext = cp()
 		return cmd.WrapError(doFmt(args, &config))
 	}

--- a/internal/commands/setup.go
+++ b/internal/commands/setup.go
@@ -178,6 +178,7 @@ var noQbecContext = map[string]bool{
 	"init":       true,
 	"completion": true,
 	"options":    true,
+	"fmt":        true,
 }
 
 func doSetup(root *cobra.Command, opts cmd.Options) {
@@ -206,6 +207,10 @@ func doSetup(root *cobra.Command, opts cmd.Options) {
 			if e == "" {
 				skipApp = true
 			}
+		}
+
+		if c.Name() == "fmt" && c.Parent().Name() == "alpha" {
+			skipApp = false
 		}
 
 		if skipApp { // do not change work dir, do not load app

--- a/site/content/userguide/usage/commands.md
+++ b/site/content/userguide/usage/commands.md
@@ -21,6 +21,7 @@ Available Commands:
   delete      delete one or more components from a Kubernetes cluster
   diff        diff one or more components against objects in a Kubernetes cluster
   env         environment lists and details
+  fmt         format jsonnet, yaml or json files
   help        Help about any command
   init        initialize a qbec app
   param       parameter lists and diffs
@@ -188,10 +189,3 @@ To see a list of experimental commands, run:
 qbec alpha --help
 ```
 
-For example, here's how you use the `fmt` command.
-
-```shell
-qbec alpha fmt -w
-```
-
-The `fmt` command would format all jsonnet and libsonnet files.


### PR DESCRIPTION
The qbec alpha fmt command has been deprecated in favor of qbec fmt.
The default behaviour of qbec fmt is backwards incompatible with qbec alpha fmt as it does not need a
qbec root context to run. If you need the old behaviour, you should use
qbec fmt <qbec-root-dir> as qbec fmt would now default to qbec fmt <cwd>.