### PR TITLE
Add support for env inheritance

### DIFF
--- a/internal/datasource/exec/exec.go
+++ b/internal/datasource/exec/exec.go
@@ -37,12 +37,14 @@ const (
 
 // Config is the configuration of the data source.
 type Config struct {
-	Command string            `json:"command"`           // the executable that is run
-	Args    []string          `json:"args,omitempty"`    // arguments to be passed to the command
-	Env     map[string]string `json:"env,omitempty"`     // environment for the command
-	Stdin   string            `json:"stdin,omitempty"`   // standard input to pass to the command
-	Timeout string            `json:"timeout,omitempty"` // command timeout as a duration string
-	timeout time.Duration     // internal representation
+	Command    string            `json:"command"`              // the executable that is run
+	Args       []string          `json:"args,omitempty"`       // arguments to be passed to the command
+	Env        map[string]string `json:"env,omitempty"`        // environment for the command
+	Stdin      string            `json:"stdin,omitempty"`      // standard input to pass to the command
+	Timeout    string            `json:"timeout,omitempty"`    // command timeout as a duration string
+	InheritEnv bool              `json:"inheritEnv,omitempty"` // Inherit env from the parent(qbec) process
+
+	timeout time.Duration // internal representation
 }
 
 func findExecutable(cmd string) (string, error) {

--- a/internal/datasource/exec/exec_test.go
+++ b/internal/datasource/exec/exec_test.go
@@ -37,45 +37,62 @@ func TestExecBasic(t *testing.T) {
 	a := assert.New(t)
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
-	ds := New("replay", "var1")
-	err = ds.Init(func(name string) (string, error) {
-		if name != "var1" {
-			return "", fmt.Errorf("invalid call to config provider, want %q got %q", "var1", name)
-		}
-		return `
+	var tests = []struct {
+		inherit bool
+	}{
+		{true}, {false},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("inhert_%t", test.inherit), func(t *testing.T) {
+			ds := New("replay", "var1")
+			os.Setenv("_akey_", "aval")
+			err = ds.Init(func(name string) (string, error) {
+				if name != "var1" {
+					return "", fmt.Errorf("invalid call to config provider, want %q got %q", "var1", name)
+				}
+				return fmt.Sprintf(`
 {
 	"command": "qbec-replay-exec",
 	"args": [ "one", "two" ],
 	"env": {
 		"foo": "bar"
 	},
-	"stdin": "input"
+	"stdin": "input",
+	"inheritEnv": %t
 }
-`, nil
-	})
-	require.NoError(t, err)
-	defer ds.Close()
-	a.Equal("replay", ds.Name())
-	str, err := ds.Resolve("/foo/bar")
-	require.NoError(t, err)
-	var data struct {
-		DSName  string   `json:"dsName"`
-		Command string   `json:"command"`
-		Args    []string `json:"args"`
-		Dir     string   `json:"dir"`
-		Env     []string `json:"env"`
-		Input   string   `json:"stdin"`
+`, test.inherit), nil
+			})
+			require.NoError(t, err)
+			defer ds.Close()
+			a.Equal("replay", ds.Name())
+			str, err := ds.Resolve("/foo/bar")
+			require.NoError(t, err)
+			var data struct {
+				DSName  string   `json:"dsName"`
+				Command string   `json:"command"`
+				Args    []string `json:"args"`
+				Dir     string   `json:"dir"`
+				Env     []string `json:"env"`
+				Input   string   `json:"stdin"`
+			}
+			err = json.Unmarshal([]byte(str), &data)
+			require.NoError(t, err)
+			a.Equal("replay", data.DSName)
+			a.Equal(exe, data.Command)
+			a.EqualValues([]string{"one", "two"}, data.Args)
+			a.Equal(pwd, data.Dir)
+			a.Contains(data.Env, "foo=bar")
+			if test.inherit {
+				a.Contains(data.Env, "_akey_=aval")
+			} else {
+				a.NotContains(data.Env, "_akey_=aval")
+			}
+			a.Contains(data.Env, "__DS_NAME__=replay")
+			a.Contains(data.Env, "__DS_PATH__=/foo/bar")
+			a.Equal("input", data.Input)
+		})
 	}
-	err = json.Unmarshal([]byte(str), &data)
-	require.NoError(t, err)
-	a.Equal("replay", data.DSName)
-	a.Equal(exe, data.Command)
-	a.EqualValues([]string{"one", "two"}, data.Args)
-	a.Equal(pwd, data.Dir)
-	a.Contains(data.Env, "foo=bar")
-	a.Contains(data.Env, "__DS_NAME__=replay")
-	a.Contains(data.Env, "__DS_PATH__=/foo/bar")
-	a.Equal("input", data.Input)
+
 }
 
 func TestExecRelativeFilePath(t *testing.T) {

--- a/internal/datasource/exec/runner.go
+++ b/internal/datasource/exec/runner.go
@@ -38,6 +38,9 @@ func (r *runner) runWithEnv(e map[string]string) (string, error) {
 
 	cmd := exec.CommandContext(ctx, r.c.Command, r.c.Args...)
 	var env []string
+	if r.c.InheritEnv {
+		env = os.Environ()
+	}
 	for k, v := range r.c.Env {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/site/content/reference/jsonnet-external-data.md
+++ b/site/content/reference/jsonnet-external-data.md
@@ -18,7 +18,7 @@ The recipe for pulling in additional data from external command output consists 
 ### Step 1: Specify a configuration for command invocation
 
 This includes program name, arguments, environment variables, and standard input. This is a JSON object with the following properties:
-  
+
 ```json
 {
   "command": "/path/to/executable",
@@ -28,6 +28,7 @@ This includes program name, arguments, environment variables, and standard input
     "environment": "variables",
   },
   "stdin": "standard input to program as a string",
+  "inheritEnv": false,
   "timeout": "10s"
 }
 ```
@@ -64,9 +65,9 @@ The above URL has 3 parts.
 * The scheme of the URL is `exec` which is the kind of data source that is being created. Currently, only `exec` is
   allowed, but we could add more schemes in the future for native integrations with specific tools.
 * The hostname in the URL is a name of your choosing. This is the data source name.
-* The `configVar` query parameter is the reference to the configuration variable using which the data source is 
+* The `configVar` query parameter is the reference to the configuration variable using which the data source is
   initialized.
-  
+
 ### Step 3: use this data source in your jsonnet component code
 
 ```jsonnet
@@ -75,11 +76,11 @@ import 'data://my-data-source/some/path'
 
 * The `data` scheme in the URI above allows qbec to determine that you want to import external data.
 * The hostname in the URI is the name of the data source that you declared.
-* The path in the URI is passed to the command as an environment variable called `__DS_PATH__`. 
+* The path in the URI is passed to the command as an environment variable called `__DS_PATH__`.
 * The command also gets another environment variable called `__DS_NAME__` that is set to the data source name.
 
 A simple command may not respect the `__DS_PATH__` environment variable and always output the same data.
-On the other hand, you can write a more complex integration (say, with Vault) by having the command use the 
+On the other hand, you can write a more complex integration (say, with Vault) by having the command use the
 information in the `__DS_PATH__` variable and emit secrets specific to that path.
 
 ## Usage notes
@@ -91,19 +92,19 @@ information in the `__DS_PATH__` variable and emit secrets specific to that path
 * Commands should behave like functions providing the same output for the same set of inputs. In particular,
   commands **should not write files** in the jsonnet source tree.
 
-* Commands are run using Go's `os/exec` package which means that they do **not** run under a shell. 
-  You cannot use pipes and redirection. 
-  If you want this functionality you need to run the command as 
+* Commands are run using Go's `os/exec` package which means that they do **not** run under a shell.
+  You cannot use pipes and redirection.
+  If you want this functionality you need to run the command as
   `[ 'sh', '-c', 'subcommand1 | subcommand2']`.
   Better yet, write a shell script that does all this.
 
 * You are responsible for ensuring that the executable you are running comes from a trusted source. Do not pull
   down executables off the internet without checking their SHA sums.
-  
+
 * In like manner, you are responsible to ensure that everyone on the team is the using the same version of the
   command that is invoked. One strategy is to download the command you want into a `.bin` directory using a
-  `Makefile` and run it from there. The Makefile downloads the same version of the command for different OS 
+  `Makefile` and run it from there. The Makefile downloads the same version of the command for different OS
   environments and checks their SHA sums.
-  
-* The command that is run does **not** inherit the OS environment from the qbec process. 
+
+* The command that is run does **not** inherit the OS environment from the qbec process.
   Only the environment variables explicitly defined in the config, as well as `__DS_NAME__` and `__DS_PATH__` are set.


### PR DESCRIPTION
Commands executed during computed var evaluation can now inherit env
from the qbec process if inhert_env is set to true.
Closes #230