### PR TITLE
Prefer kubectl pristine over qbec

### DIFF
--- a/internal/remote/pristine.go
+++ b/internal/remote/pristine.go
@@ -164,7 +164,7 @@ func (f fallbackPristine) getPristine(annotations map[string]string, orig *unstr
 }
 
 func getPristineVersion(obj *unstructured.Unstructured, includeFallback bool) (*unstructured.Unstructured, string) {
-	pristineReaders := []pristineReader{qbecPristine{}, kubectlPristine{}}
+	pristineReaders := []pristineReader{kubectlPristine{}, qbecPristine{}}
 	if includeFallback {
 		pristineReaders = append(pristineReaders, fallbackPristine{})
 	}

--- a/internal/remote/pristine_test.go
+++ b/internal/remote/pristine_test.go
@@ -139,6 +139,15 @@ func testPristineReader(t *testing.T, useFallback bool) {
 			},
 		},
 		{
+			file: "both-applied.yaml",
+			asserter: func(t *testing.T, obj *unstructured.Unstructured, source string) {
+				a := assert.New(t)
+				a.Equal("kubectl annotation", source)
+				a.NotNil(obj)
+				a.NotEqual("", obj.GetAnnotations()[kubectlLastConfig])
+			},
+		},
+		{
 			name: "qbec-bad.yaml",
 			file: "qbec-applied.yaml",
 			mod: func(obj *unstructured.Unstructured) {

--- a/internal/remote/testdata/pristine/both-applied.yaml
+++ b/internal/remote/testdata/pristine/both-applied.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  data-1: value-1
+  data-2: value-4
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","data":{"data-1":"value-1","data-2":"value-4"},"kind":"ConfigMap","metadata":{"annotations":{"qbec.io/component":"cm"},"labels":{"qbec.io/application":"test","qbec.io/environment":"default"},"name":"test-configmap","namespace":"istio-test"}}
+    qbec.io/component: cm
+    qbec.io/last-applied: H4sIAAAAAAAA/1SOsU7FMAxFdz7jzgnoIaaszKzsfqmLLBI7tG6Xqv+OUmilN1m+9/jIG6jJJ0+zmCJhvSFgICek7Zjx1lMqC8eziq9X9IY94Ft0QMK76ShfH9QQUNnptJCqObmYzn39uXN+FnvJVpspqyMh1+4pdOfywFBrRfJxiwTn2RGuknWVybT+KQYeaSnePUqV//GYj6cqNez70y8AAAD//wEAAP//CtqlhewAAAA=
+  creationTimestamp: "2021-04-08T15:05:47Z"
+  labels:
+    qbec.io/application: test
+    qbec.io/environment: default
+  name: test-configmap
+  namespace: istio-test
+  resourceVersion: "679364782"
+  uid: d0724aac-42e5-4c58-8b17-d66d40aa178a


### PR DESCRIPTION
When both pristine exists, most problably last apply operation was done
via kubectl, thus it contains more actual data than qbec pristine.

This PR implements logic described on #232 and adds additional test for that case.