### PR TITLE
allow glob paths to refer to files outside the working dir

### DIFF
--- a/internal/vm/importers/glob.go
+++ b/internal/vm/importers/glob.go
@@ -162,8 +162,8 @@ func (g *GlobImporter) Import(importedFrom, importedPath string) (contents jsonn
 		})
 	}()
 
-	fsys := os.DirFS(".")
-	matches, err := doublestar.Glob(fsys, filepath.ToSlash(globPath))
+	fsDir, pat := doublestar.SplitPattern(filepath.ToSlash(globPath))
+	matches, err := doublestar.Glob(os.DirFS(fsDir), pat)
 	if err != nil {
 		return contents, foundAt, fmt.Errorf("unable to expand glob %q, %v", globPath, err)
 	}
@@ -171,6 +171,7 @@ func (g *GlobImporter) Import(importedFrom, importedPath string) (contents jsonn
 	// convert matches to be relative to our baseDir
 	var relativeMatches []string
 	for _, m := range matches {
+		m = path.Join(fsDir, m)
 		rel, err := filepath.Rel(baseDir, m)
 		if err != nil {
 			return contents, globPath, fmt.Errorf("could not resolve %s from %s", m, importedFrom)

--- a/internal/vm/importers/glob_test.go
+++ b/internal/vm/importers/glob_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-jsonnet"
@@ -106,6 +107,22 @@ func TestGlobDoublestar(t *testing.T) {
 	err := json.Unmarshal([]byte(expectedJSON), &expected)
 	require.Nil(t, err)
 	assert.EqualValues(t, expected, data)
+}
+
+func TestGlobOutsideRoot(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	dir := filepath.FromSlash("testdata/example1/caller2")
+	err = os.Chdir(dir)
+	require.NoError(t, err)
+	defer func() {
+		err := os.Chdir(wd)
+		require.NoError(t, err)
+	}()
+	vm, _ := makeVM()
+	data := evaluateVirtual(t, vm, "caller.jsonnet", `import 'glob-import:../*json'`)
+	_, ok := data["../a.json"]
+	require.True(t, ok)
 }
 
 func TestDuplicateFileName(t *testing.T) {


### PR DESCRIPTION
currently glob imports that are outside the working directory (usually the qbec root) do not work because we create a DirFS rooted at $(pwd). This is inconsistent with the way jsonnet allows import paths from anywhere within the file system.

Fix this.