### PR TITLE
Automatic params.libsonnet

### DIFF
--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -65,16 +65,14 @@ base {
 
 var paramsTemplate = template.Must(template.New("any-env").Parse(`
 // this file returns the params for the current qbec environment
-// you need to add an entry here every time you add a new environment.
-
 local env = std.extVar('qbec.io/env');
-local paramsMap = {
-  _: import './environments/base.libsonnet',
-  default: import './environments/default.libsonnet',
-};
+local paramsMap = import 'glob-import:environments/*.libsonnet';
+local baseFile = if env == '_' then 'base' else env;
+local key = 'environments/%s.libsonnet' % baseFile;
 
-if std.objectHas(paramsMap, env) then paramsMap[env] else error 'environment ' + env + ' not defined in ' + std.thisFile
-
+if std.objectHas(paramsMap, key)
+then paramsMap[key]
+else error 'no param file %s found for environment %s' % [key, env]
 `))
 
 var componentExampleTemplate = template.Must(template.New("comp").Parse(`


### PR DESCRIPTION
Currently `qbec init` generates the following `params.libsonnet` file:
```jsonnet

// this file returns the params for the current qbec environment
// you need to add an entry here every time you add a new environment.

local env = std.extVar('qbec.io/env');
local paramsMap = {
  _: import './environments/base.libsonnet',
  default: import './environments/default.libsonnet',
};

if std.objectHas(paramsMap, env) then paramsMap[env] else error 'environment ' + env + ' not defined in ' + std.thisFile

```

This PR changing it's content to:

```jsonnet

// this file returns the params for the current qbec environment

local env = std.extVar('qbec.io/env');
local environments = std.objectFields(std.native('parseYaml')(importstr 'qbec.yaml')[0].spec.environments);
local p = import 'glob-import:environments/*.libsonnet';
local paramsMap = { _: p['environments/base.libsonnet'] } +
                  { [x]: p['environments/' + x + '.libsonnet'] for x in environments };

if std.objectHas(paramsMap, env) then paramsMap[env] else error 'environment ' + env + ' not defined in qbec.yaml'

```

which will automatically discovers environments from qbec.yaml and imports them using `glob-import:environments/*.libsonnet`