### PR TITLE
Add support for --api-versions flag for helm template 

### DIFF
--- a/site/content/reference/jsonnet-native-funcs.md
+++ b/site/content/reference/jsonnet-native-funcs.md
@@ -46,6 +46,7 @@ This object supports the following keys:
 * `execute` (array of strings) - the `--execute` argument to the template command
 * `kubeVersion` (string) - the `--kube-version` argument to the template command
 * `verbose` (bool) - print `helm template` command invocation to standard error before executing it
+* `apiVersions` (array of strings) - the `--api-versions` argument to the template command
 
 
 ## parseJson

--- a/vm/internal/natives/helm.go
+++ b/vm/internal/natives/helm.go
@@ -37,6 +37,7 @@ type helmOptions struct {
 	Name         string   `json:"name"`         // --name option
 	NameTemplate string   `json:"nameTemplate"` // --name-template option
 	Namespace    string   `json:"namespace"`    // --namespace option
+	ApiVersions  []string `json:"apiVersions"`  // --api-versions options
 	ThisFile     string   `json:"thisFile"`     // use supplied file as current file to resolve relative refs, should be set to std.thisFile
 	Verbose      bool     `json:"verbose"`      // print helm template command before executing it
 	//IsUpgrade    bool     `json:"isUpgrade"` // --is-upgrade option, defer adding this until implications are known,
@@ -61,6 +62,11 @@ func (h helmOptions) toArgs() []string {
 	}
 	if h.Namespace != "" {
 		ret = append(ret, "--namespace", h.Namespace)
+	}
+	if len(h.ApiVersions) > 0 {
+		for _, e := range h.ApiVersions {
+			ret = append(ret, "--api-versions", e)
+		}
 	}
 	//if h.IsUpgrade {
 	//	ret = append(ret, "--is-upgrade")

--- a/vm/internal/natives/helm_test.go
+++ b/vm/internal/natives/helm_test.go
@@ -68,7 +68,7 @@ func TestHelmSimpleExpand(t *testing.T) {
 	err = json.Unmarshal([]byte(code), &output)
 	require.Nil(t, err)
 
-	require.Equal(t, 2, len(output))
+	require.Equal(t, 3, len(output))
 
 	sort.Slice(output, func(i, j int) bool {
 		return output[i].Kind < output[j].Kind
@@ -82,6 +82,9 @@ func TestHelmSimpleExpand(t *testing.T) {
 	a.Equal("baz", ob.Data["bar"])
 
 	ob = output[1]
+	a.Equal("networking.k8s.io/v1", ob.APIVersion)
+
+	ob = output[2]
 	a.Equal("Secret", ob.Kind)
 	a.Equal("my-ns", ob.Metadata.Namespace)
 	a.Equal("my-name", ob.Metadata.Name)

--- a/vm/internal/natives/testdata/bad-relative.jsonnet
+++ b/vm/internal/natives/testdata/bad-relative.jsonnet
@@ -1,13 +1,13 @@
 local expandHelmTemplate = std.native('expandHelmTemplate');
 
 expandHelmTemplate(
-    './charts/foobar',
-    {
-        foo: 'barbar',
-    },
-    {
-        namespace: 'my-ns',
-        name: 'my-name',
-		verbose: true,
-    }
+  './charts/foobar',
+  {
+    foo: 'barbar',
+  },
+  {
+    namespace: 'my-ns',
+    nameTemplate: 'my-name',
+    verbose: true,
+  }
 )

--- a/vm/internal/natives/testdata/charts/foobar/templates/ingress.yaml
+++ b/vm/internal/natives/testdata/charts/foobar/templates/ingress.yaml
@@ -1,0 +1,34 @@
+---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: name-virtual-host-ingress
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service: 
+            name: service1
+            port:
+              number: 80
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: name-virtual-host-ingress
+spec:
+  rules:
+    - host: foo.bar.com
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: service1
+            servicePort: 80
+{{- end }}

--- a/vm/internal/natives/testdata/consumer.jsonnet
+++ b/vm/internal/natives/testdata/consumer.jsonnet
@@ -1,14 +1,17 @@
 local expandHelmTemplate = std.native('expandHelmTemplate');
 
 expandHelmTemplate(
-    './charts/foobar',
-    {
-        foo: 'barbar',
-    },
-    {
-        namespace: 'my-ns',
-        nameTemplate: 'my-name',
-        thisFile: std.thisFile,
-		verbose: true,
-    }
+  './charts/foobar',
+  {
+    foo: 'barbar',
+  },
+  {
+    namespace: 'my-ns',
+    nameTemplate: 'my-name',
+    thisFile: std.thisFile,
+    verbose: true,
+    apiVersions: [
+      'networking.k8s.io/v1/Ingress',
+    ],
+  }
 )


### PR DESCRIPTION
This PR adds support for passing `--api-versions` to helm template command.
Many charts containing lookup functions, which allow to check if Kubernetes cluster supports specific apiVersions
https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function