### PR TITLE
Update codocov action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Test
         run: |
           make test TEST_FLAGS="-timeout 3m -tags integration"
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
v1 bash uploader is being sunset. https://link.codecov.io/dc/c4Ov1985SwsWm5MPGNpcMw-Obgt-2sNfkSeoTNUIZRLfsC9s1y01DI4jytsOzP75Ngz1CSaMNq1tbBgJW8wxTpT9xf9M6dNWyH8WDd_1Sn6ltZBXKOB7i5VdS9FxSb-7m_JokjUq3GrVlTZgkUPDpA==/MzMyLUxWWC03NDEAAAGAGSkf8tDthPRTidfj3KYrs-JzoypAcEQ9Bid-fkL-d4ZKIeMwGUGjG8XMfZL8NvXMbodFvxo=