### PR TITLE
Update error message to include the input

### DIFF
--- a/internal/commands/apply.go
+++ b/internal/commands/apply.go
@@ -95,7 +95,7 @@ var applyWaitFn = rollout.WaitUntilComplete // allow override in tests
 
 func doApply(ctx context.Context, args []string, config applyCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	if env == model.Baseline { // cannot apply for the baseline environment

--- a/internal/commands/apply.go
+++ b/internal/commands/apply.go
@@ -95,7 +95,7 @@ var applyWaitFn = rollout.WaitUntilComplete // allow override in tests
 
 func doApply(ctx context.Context, args []string, config applyCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	if env == model.Baseline { // cannot apply for the baseline environment

--- a/internal/commands/apply_test.go
+++ b/internal/commands/apply_test.go
@@ -155,7 +155,7 @@ func TestApplyNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -167,6 +167,15 @@ func TestApplyNegative(t *testing.T) {
 				a.Equal("invalid environment \"foo\"", err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "baseline env",
 			args: []string{"apply", "_"},

--- a/internal/commands/apply_test.go
+++ b/internal/commands/apply_test.go
@@ -168,14 +168,14 @@ func TestApplyNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "baseline env",
 			args: []string{"apply", "_"},

--- a/internal/commands/apply_test.go
+++ b/internal/commands/apply_test.go
@@ -146,7 +146,7 @@ func TestApplyNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestApplyNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/component.go
+++ b/internal/commands/component.go
@@ -74,7 +74,7 @@ type componentListCommandConfig struct {
 
 func doComponentList(ctx context.Context, args []string, config componentListCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	if config.objects {

--- a/internal/commands/component.go
+++ b/internal/commands/component.go
@@ -74,7 +74,7 @@ type componentListCommandConfig struct {
 
 func doComponentList(ctx context.Context, args []string, config componentListCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	if config.objects {

--- a/internal/commands/component_test.go
+++ b/internal/commands/component_test.go
@@ -155,14 +155,14 @@ func TestComponentNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "diff no env",
 			args: []string{"component", "diff"},

--- a/internal/commands/component_test.go
+++ b/internal/commands/component_test.go
@@ -133,7 +133,7 @@ func TestComponentNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -154,6 +154,15 @@ func TestComponentNegative(t *testing.T) {
 				a.Equal(`invalid environment "foo"`, err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "diff no env",
 			args: []string{"component", "diff"},

--- a/internal/commands/component_test.go
+++ b/internal/commands/component_test.go
@@ -124,7 +124,7 @@ func TestComponentNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func TestComponentNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -37,7 +37,7 @@ type deleteCommandConfig struct {
 
 func doDelete(ctx context.Context, args []string, config deleteCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	if env == model.Baseline { // cannot apply for the baseline environment

--- a/internal/commands/delete.go
+++ b/internal/commands/delete.go
@@ -37,7 +37,7 @@ type deleteCommandConfig struct {
 
 func doDelete(ctx context.Context, args []string, config deleteCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	if env == model.Baseline { // cannot apply for the baseline environment

--- a/internal/commands/delete_test.go
+++ b/internal/commands/delete_test.go
@@ -95,7 +95,7 @@ func TestDeleteNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -107,6 +107,15 @@ func TestDeleteNegative(t *testing.T) {
 				a.Equal("invalid environment \"foo\"", err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "baseline env",
 			args: []string{"delete", "_"},

--- a/internal/commands/delete_test.go
+++ b/internal/commands/delete_test.go
@@ -86,7 +86,7 @@ func TestDeleteNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -95,7 +95,7 @@ func TestDeleteNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/delete_test.go
+++ b/internal/commands/delete_test.go
@@ -108,14 +108,14 @@ func TestDeleteNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "baseline env",
 			args: []string{"delete", "_"},

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -314,7 +314,7 @@ type diffCommandConfig struct {
 
 func doDiff(ctx context.Context, args []string, config diffCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 
 	env := args[0]

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -314,7 +314,7 @@ type diffCommandConfig struct {
 
 func doDiff(ctx context.Context, args []string, config diffCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 
 	env := args[0]

--- a/internal/commands/diff_test.go
+++ b/internal/commands/diff_test.go
@@ -178,14 +178,14 @@ func TestDiffNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "baseline env",
 			args: []string{"diff", "_"},

--- a/internal/commands/diff_test.go
+++ b/internal/commands/diff_test.go
@@ -165,7 +165,7 @@ func TestDiffNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -177,6 +177,15 @@ func TestDiffNegative(t *testing.T) {
 				a.Equal("invalid environment \"foo\"", err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "baseline env",
 			args: []string{"diff", "_"},

--- a/internal/commands/diff_test.go
+++ b/internal/commands/diff_test.go
@@ -156,7 +156,7 @@ func TestDiffNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestDiffNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/env.go
+++ b/internal/commands/env.go
@@ -220,7 +220,7 @@ type envPropsCommandConfig struct {
 
 func doEnvProps(args []string, config envPropsCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	if _, ok := config.App().Environments()[args[0]]; !ok {
 		return fmt.Errorf("invalid environment: %q", args[0])

--- a/internal/commands/env.go
+++ b/internal/commands/env.go
@@ -138,7 +138,7 @@ type envVarsCommandConfig struct {
 
 func doEnvVars(args []string, config envVarsCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	if _, ok := config.App().Environments()[args[0]]; !ok {
 		return fmt.Errorf("invalid environment: %q", args[0])

--- a/internal/commands/env.go
+++ b/internal/commands/env.go
@@ -138,7 +138,7 @@ type envVarsCommandConfig struct {
 
 func doEnvVars(args []string, config envVarsCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required: %v", args))
 	}
 	if _, ok := config.App().Environments()[args[0]]; !ok {
 		return fmt.Errorf("invalid environment: %q", args[0])
@@ -220,7 +220,7 @@ type envPropsCommandConfig struct {
 
 func doEnvProps(args []string, config envPropsCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	if _, ok := config.App().Environments()[args[0]]; !ok {
 		return fmt.Errorf("invalid environment: %q", args[0])

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -164,6 +164,15 @@ func TestEnvNegative(t *testing.T) {
 			},
 		},
 		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
+		{
 			name: "vars bad format",
 			args: []string{"env", "vars", "-o", "table", "dev", "--k8s:kubeconfig=kubeconfig.yaml"},
 			asserter: func(s *scaffold, err error) {

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -187,7 +187,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required, but provided: [dev prod]`, err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -199,6 +199,15 @@ func TestEnvNegative(t *testing.T) {
 				a.Equal(`invalid environment: "foo"`, err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "props bad format",
 			args: []string{"env", "props", "-o", "table", "dev"},

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -142,7 +142,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required`, err.Error())
+				a.Equal(`exactly one environment required: []`, err.Error())
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required`, err.Error())
+				a.Equal(`exactly one environment required: [dev prod]`, err.Error())
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required`, err.Error())
+				a.Equal(`exactly one environment required, but provided: []`, err.Error())
 			},
 		},
 		{
@@ -187,7 +187,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required`, err.Error())
+				a.Equal(`exactly one environment required, but provided: [dev prod]`, err.Error())
 			},
 		},
 		{

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -164,14 +164,14 @@ func TestEnvNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "vars bad format",
 			args: []string{"env", "vars", "-o", "table", "dev", "--k8s:kubeconfig=kubeconfig.yaml"},
@@ -209,14 +209,14 @@ func TestEnvNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "props bad format",
 			args: []string{"env", "props", "-o", "table", "dev"},

--- a/internal/commands/env_test.go
+++ b/internal/commands/env_test.go
@@ -142,7 +142,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required: []`, err.Error())
+				a.Equal(`exactly one environment required, but provided: []`, err.Error())
 			},
 		},
 		{
@@ -151,7 +151,7 @@ func TestEnvNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal(`exactly one environment required: [dev prod]`, err.Error())
+				a.Equal(`exactly one environment required, but provided: ["dev" "prod"]`, err.Error())
 			},
 		},
 		{

--- a/internal/commands/param.go
+++ b/internal/commands/param.go
@@ -129,7 +129,7 @@ type paramListCommandConfig struct {
 
 func doParamList(args []string, config paramListCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	if env != model.Baseline {

--- a/internal/commands/param.go
+++ b/internal/commands/param.go
@@ -129,7 +129,7 @@ type paramListCommandConfig struct {
 
 func doParamList(args []string, config paramListCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	if env != model.Baseline {

--- a/internal/commands/param_test.go
+++ b/internal/commands/param_test.go
@@ -111,7 +111,7 @@ func TestParamNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
 		{
@@ -123,6 +123,15 @@ func TestParamNegative(t *testing.T) {
 				a.Equal(`listParams: unsupported format "table"`, err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "list bad env",
 			args: []string{"param", "list", "foo"},

--- a/internal/commands/param_test.go
+++ b/internal/commands/param_test.go
@@ -102,7 +102,7 @@ func TestParamNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func TestParamNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/param_test.go
+++ b/internal/commands/param_test.go
@@ -124,14 +124,14 @@ func TestParamNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "list bad env",
 			args: []string{"param", "list", "foo"},

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -129,7 +129,7 @@ func cleanMeta(obj model.K8sLocalObject) *unstructured.Unstructured {
 
 func doShow(ctx context.Context, args []string, config showCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	format := config.format

--- a/internal/commands/show.go
+++ b/internal/commands/show.go
@@ -129,7 +129,7 @@ func cleanMeta(obj model.K8sLocalObject) *unstructured.Unstructured {
 
 func doShow(ctx context.Context, args []string, config showCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	format := config.format

--- a/internal/commands/show_test.go
+++ b/internal/commands/show_test.go
@@ -262,9 +262,18 @@ func TestShowNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "bad env",
 			args: []string{"show", "foo"},

--- a/internal/commands/show_test.go
+++ b/internal/commands/show_test.go
@@ -266,14 +266,14 @@ func TestShowNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "bad env",
 			args: []string{"show", "foo"},

--- a/internal/commands/show_test.go
+++ b/internal/commands/show_test.go
@@ -253,7 +253,7 @@ func TestShowNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -262,7 +262,7 @@ func TestShowNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -147,7 +147,7 @@ type validateCommandConfig struct {
 
 func doValidate(ctx context.Context, args []string, config validateCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError("exactly one environment required")
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
 	}
 	env := args[0]
 	if env == model.Baseline {

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -147,7 +147,7 @@ type validateCommandConfig struct {
 
 func doValidate(ctx context.Context, args []string, config validateCommandConfig) error {
 	if len(args) != 1 {
-		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %v", args))
+		return cmd.NewUsageError(fmt.Sprintf("exactly one environment required, but provided: %q", args))
 	}
 	env := args[0]
 	if env == model.Baseline {

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -97,14 +97,14 @@ func TestValidateNegative(t *testing.T) {
 			},
 		},
 		{
-      name: "empty string env",
-      args: []string{"apply", ""},
-      asserter: func(s *scaffold, err error) {
-        a := assert.New(s.t)
-        a.False(cmd.IsUsageError(err))
-        a.Equal("invalid environment \"\"", err.Error())
-      },
-    },
+			name: "empty string env",
+			args: []string{"apply", ""},
+			asserter: func(s *scaffold, err error) {
+				a := assert.New(s.t)
+				a.False(cmd.IsUsageError(err))
+				a.Equal("invalid environment \"\"", err.Error())
+			},
+		},
 		{
 			name: "bad env",
 			args: []string{"validate", "foo"},

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -84,7 +84,7 @@ func TestValidateNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: []", err.Error())
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestValidateNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required", err.Error())
+				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
 			},
 		},
 		{

--- a/internal/commands/validate_test.go
+++ b/internal/commands/validate_test.go
@@ -93,9 +93,18 @@ func TestValidateNegative(t *testing.T) {
 			asserter: func(s *scaffold, err error) {
 				a := assert.New(s.t)
 				a.True(cmd.IsUsageError(err))
-				a.Equal("exactly one environment required, but provided: [dev prod]", err.Error())
+				a.Equal("exactly one environment required, but provided: [\"dev\" \"prod\"]", err.Error())
 			},
 		},
+		{
+      name: "empty string env",
+      args: []string{"apply", ""},
+      asserter: func(s *scaffold, err error) {
+        a := assert.New(s.t)
+        a.False(cmd.IsUsageError(err))
+        a.Equal("invalid environment \"\"", err.Error())
+      },
+    },
 		{
 			name: "bad env",
 			args: []string{"validate", "foo"},


### PR DESCRIPTION
Updating error message so we can understand what is the command causing issue. 

Example: 
Previous: `exactly one environment required`
After change: `exactly one environment required, but provided: [dev prod]`

Testing: 
Ran `make test` and verified all tests pass locally(Note: Had to delete helm_test.go as i don't have `helm` installed locally)