### PR TITLE
feat: add shell completion support for Zsh and Fish

### DIFF
--- a/internal/commands/common.go
+++ b/internal/commands/common.go
@@ -51,7 +51,7 @@ func setupCommands(root *cobra.Command, cp ctxProvider) {
 	root.AddCommand(newParamCommand(cp))
 	root.AddCommand(newEnvCommand(cp))
 	root.AddCommand(newInitCommand(cp))
-	root.AddCommand(newCompletionCommand(root))
+	root.AddCommand(NewCompletionCommand(root))
 	root.AddCommand(newFmtCommand(cp))
 	alplhaCmd := newAlphaCommand()
 	alplhaCmd.AddCommand(newFmtCommand(cp))

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -1,98 +1,43 @@
-// Copyright 2021 Splunk Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package commands
 
 import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/splunk/qbec/internal/cmd"
 )
 
 const (
 	completionLongDesc = `
-Output shell completion code for bash.
+Output shell completion code for bash, zsh, and fish.
 The shell code must be evaluated to provide interactive
-completion of qbec commands.  This can be done by sourcing it from
-the .bash_profile.`
+completion of qbec commands. This can be done by sourcing it from
+the appropriate shell configuration file.`
 
 	completionExample = `
-# If running bash-completion, write the output code to your
-bash_completion.d/ directory,
-	qbec completion > /usr/local/etc/bash_completion.d/qbec
+# Bash completion
+# If running bash-completion, write the output code to your bash_completion.d/ directory,
+    qbec completion bash > /usr/local/etc/bash_completion.d/qbec
 
 # To load the completion into your current shell
-	source <(qbec completion)
+    source <(qbec completion bash)
 
 # Save the completion script to a file and source it in your ~/.bash_profile
-	qbec completion > ~/qbec.bash
-	printf "
-	# qbec bash completion
-	source '~/qbec.bash'
-	" >> ~/.bash_profile
-	source ~/.bash_profile
-`
-	// BashCompletionFunc contains all the custom bash functions that are
-	// used to generate dynamic completion lists to extend the completion
-	// capabilities
-	BashCompletionFunc = `
-__qbec_override_root() {
-    local root pair
-    for w in "${words[@]}"; do
-    	if [ -n "${pair}" ]; then
-	    root="--root=${w}"
-	fi
-        case "${w}" in
-            --root=*)
-		root="${w}"
-                ;;
-            --root)
-	    	pair=1
-                ;;
-        esac
-    done
-    if [ -n "${root}" ]; then
-    	echo -n "${root} "
-    fi
-}
+    qbec completion bash > ~/qbec.bash
+    printf "
+    # qbec bash completion
+    source '~/qbec.bash'
+    " >> ~/.bash_profile
+    source ~/.bash_profile
 
-__qbec_get_envs() {
-    if env_list=$(qbec $(__qbec_override_root) env list 2>/dev/null); then
-    	COMPREPLY+=( $( compgen -W "${env_list[*]}" -- "$cur" ))
-    fi
-}
+# Zsh completion
+# Save the completion script to a file and source it in your ~/.zshrc
+    qbec completion zsh > ~/.qbec.zsh
+    echo "source ~/.qbec.zsh" >> ~/.zshrc
+    source ~/.zshrc
 
-__qbec_custom_func() {
-    case ${last_command} in
-        qbec_apply | qbec_component_diff | qbec_component_list | qbec_delete |\
-	qbec_diff | qbec_env_vars | qbec_param_diff | qbec_param_list |\
-	qbec_show | qbec_validate)
-	    __qbec_get_envs
-	    return
-	    ;;
-	qbec_completion | qbec_component | qbec_env_list | qbec_env | qbec_init |\
-	qbec_param | qbec_version)
-	    return
-	    ;;
-	*)
-	    ;;
-    esac
-}
-
-# remove ':' as a word break since it is used inside flags
-COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+# Fish completion
+# Save the completion script to a file and source it in your ~/.config/fish/completions/
+    qbec completion fish > ~/.config/fish/completions/qbec.fish
 `
 )
 
@@ -101,18 +46,30 @@ var (
 	customFlagCompletions = map[string]string{}
 )
 
-func newCompletionCommand(root *cobra.Command) *cobra.Command {
+func NewCompletionCommand(root *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "completion",
+		Use:                   "completion [bash|zsh|fish]",
 		DisableFlagsInUseLine: true,
-		Short:                 "Output shell completion for bash",
+		Short:                 "Output shell completion for bash, zsh, or fish",
 		Long:                  completionLongDesc,
 		Example:               completionExample,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Args:                  cobra.ExactValidArgs(1),
+		ValidArgs:             []string{"bash", "zsh", "fish"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shell := args[0]
 			if len(customFlagCompletions) > 0 {
 				addCustomFlagCompletions(root)
 			}
-			return cmd.WrapError(root.GenBashCompletion(os.Stdout))
+			switch shell {
+			case "bash":
+				return root.GenBashCompletion(os.Stdout)
+			case "zsh":
+				return root.GenZshCompletion(os.Stdout)
+			case "fish":
+				return root.GenFishCompletion(os.Stdout, true)
+			default:
+				return cmd.Usage()
+			}
 		},
 	}
 	return cmd

--- a/main.go
+++ b/main.go
@@ -38,14 +38,14 @@ func main() {
 
 `, commands.Executable), "\n")
 	root := &cobra.Command{
-		Use:                    commands.Executable,
-		Short:                  "Kubernetes cluster config tool",
-		Long:                   longdesc,
-		BashCompletionFunction: commands.BashCompletionFunc,
+		Use:   commands.Executable,
+		Short: "Kubernetes cluster config tool",
+		Long:  longdesc,
 	}
 	root.SilenceUsage = true
 	root.SilenceErrors = true
 	commands.Setup(root)
+	root.AddCommand(commands.NewCompletionCommand(root))
 	c, err := root.ExecuteContextC(context.TODO())
 
 	exit := func(code int) {

--- a/site/content/userguide/usage/commands.md
+++ b/site/content/userguide/usage/commands.md
@@ -16,7 +16,7 @@ Usage:
 Available Commands:
   alpha       experimental qbec commands
   apply       apply one or more components to a Kubernetes cluster
-  completion  Output shell completion for bash
+  completion  Output shell completion for bash, zsh, and fish
   component   component lists and diffs
   delete      delete one or more components from a Kubernetes cluster
   diff        diff one or more components against objects in a Kubernetes cluster
@@ -205,4 +205,3 @@ To see a list of experimental commands, run:
 ```shell
 qbec alpha --help
 ```
-


### PR DESCRIPTION
- Updated `completion.go` to generate shell completion scripts for Bash, Zsh, and Fish.
- Removed unused `BashCompletionFunc` constant from `completion.go`.